### PR TITLE
Fix NextAuth v5 configuration for Vercel deployment

### DIFF
--- a/src/lib/auth.config.ts
+++ b/src/lib/auth.config.ts
@@ -8,6 +8,9 @@
 import type { NextAuthConfig } from "next-auth";
 
 export const authConfig: NextAuthConfig = {
+  // Explicitly set secret - NextAuth v5 uses AUTH_SECRET by default
+  // We support both AUTH_SECRET and NEXTAUTH_SECRET for flexibility
+  secret: process.env.AUTH_SECRET || process.env.NEXTAUTH_SECRET,
   session: {
     strategy: "jwt",
   },

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -38,6 +38,7 @@ declare module "next-auth/jwt" {
 
 export const { handlers, auth, signIn, signOut } = NextAuth({
   ...authConfig,
+  trustHost: true, // Required for Vercel deployments
   adapter: PrismaAdapter(prisma) as any,
   providers: [
     Credentials({


### PR DESCRIPTION
- Add explicit secret config supporting both AUTH_SECRET and NEXTAUTH_SECRET
- Add trustHost: true for Vercel proxy compatibility
- Fixes "Server error" on login/signup pages