### PR TITLE
Fix Python global declaration error in api_server.py

### DIFF
--- a/python_ai/api_server.py
+++ b/python_ai/api_server.py
@@ -148,7 +148,6 @@ def get_pipeline():
                     logger.warning(f"LSTM training failed: {e}")
 
             # Set global pipeline
-            global pipeline
             pipeline = pipeline_instance
             return pipeline
 


### PR DESCRIPTION
Remove duplicate 'global pipeline' declaration that was causing "name 'pipeline' is used prior to global declaration" error in Python 3.11