### PR TITLE
Fix Railway $PORT expansion by wrapping startCommand in shell

### DIFF
--- a/python_ai/railway.toml
+++ b/python_ai/railway.toml
@@ -3,7 +3,7 @@ builder = "dockerfile"
 dockerfilePath = "Dockerfile"
 
 [deploy]
-startCommand = "uvicorn api_server:app --host 0.0.0.0 --port $PORT"
+startCommand = "sh -c 'uvicorn api_server:app --host 0.0.0.0 --port $PORT'"
 healthcheckPath = "/"
 healthcheckTimeout = 600
 restartPolicyType = "ON_FAILURE"


### PR DESCRIPTION
The Railway runtime was failing with 'Invalid value for --port: $PORT is not a valid integer' because the startCommand wasn't being executed through a shell, so $PORT wasn't expanded. Wrapping the command in 'sh -c' ensures proper environment variable expansion.