### PR TITLE
Remove startCommand from railway.toml to use Dockerfile CMD

### DIFF
--- a/python_ai/railway.toml
+++ b/python_ai/railway.toml
@@ -3,7 +3,6 @@ builder = "dockerfile"
 dockerfilePath = "Dockerfile"
 
 [deploy]
-startCommand = "sh -c 'uvicorn api_server:app --host 0.0.0.0 --port $PORT'"
 healthcheckPath = "/"
 healthcheckTimeout = 600
 restartPolicyType = "ON_FAILURE"


### PR DESCRIPTION
Let the Dockerfile CMD handle the startup command, which uses proper JSON format: ["sh", "-c", "uvicorn ... --port $PORT"] for reliable environment variable expansion.