### PR TITLE
Switch to gunicorn for production stability

### DIFF
--- a/python_ai/Dockerfile
+++ b/python_ai/Dockerfile
@@ -51,5 +51,5 @@ ENV PORT=8000
 # Expose port
 EXPOSE 8000
 
-# Run the API server using JSON format as recommended
-CMD ["sh", "-c", "uvicorn api_server:app --host 0.0.0.0 --port $PORT"]
+# Run the API server with gunicorn (more robust for production)
+CMD ["sh", "-c", "gunicorn api_server:app --bind 0.0.0.0:$PORT --worker-class uvicorn.workers.UvicornWorker --workers 1 --timeout 120 --keep-alive 5 --access-logfile - --error-logfile -"]

--- a/python_ai/requirements.txt
+++ b/python_ai/requirements.txt
@@ -12,6 +12,7 @@ yfinance>=0.2.30
 # API Server
 fastapi>=0.109.0
 uvicorn>=0.27.0
+gunicorn>=21.0.0
 pydantic>=2.5.0
 
 # HTTP client for live data


### PR DESCRIPTION
- Add gunicorn to requirements.txt
- Use gunicorn with uvicorn workers instead of plain uvicorn
- Add timeout and keep-alive settings for better reliability
- Enable access and error logging to stdout/stderr