### PR TITLE
Add real market data integration using yfinance

### DIFF
--- a/python_ai/api_server.py
+++ b/python_ai/api_server.py
@@ -86,7 +86,7 @@ class AnalysisRequest(BaseModel):
     ticker: str = Field(..., description="Stock ticker or crypto symbol")
     asset_type: str = Field(default="stock", description="Asset type: 'stock' or 'crypto'")
     days: int = Field(default=90, description="Days of historical data to analyze")
-    use_live_data: bool = Field(default=False, description="Use live API data if available")
+    use_live_data: bool = Field(default=True, description="Use live API data (real market data from yfinance)")
 
 
 class SignalDetail(BaseModel):


### PR DESCRIPTION
- Implement load_stock_data with yfinance for real price history
- Implement get_stock_fundamentals with yfinance for real company data
- Detect OTC/penny stocks, micro-cap status from actual exchange data
- Default to use_live_data=True for real market analysis
- Fallback to synthetic data if yfinance fails

This enables meaningful differentiation between legitimate stocks (AAPL) and potentially risky stocks (SVRE, penny stocks, OTC) based on real data.