### PR TITLE
Fix JSX syntax error: mismatched a/Link tags in Header.tsx

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -170,7 +170,7 @@ export function Header({ onSidebarToggle, usage, onShare, showShare }: HeaderPro
                         <HelpCircle className="h-4 w-4" />
                         Help
                       </button>
-                    </Link>
+                    </a>
 
                     <div className="border-t border-border mt-2 pt-2">
                       <button


### PR DESCRIPTION
Changed closing </Link> to </a> to match the opening <a> tag for the Help link. This was causing build failures on Vercel.