### PR TITLE
Fix JSX syntax error: change </a> to </Link> for Help menu item

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -166,7 +166,7 @@ export function Header({ onSidebarToggle, usage, onShare, showShare }: HeaderPro
                         <HelpCircle className="h-4 w-4" />
                         Help
                       </button>
-                    </a>
+                    </Link>
 
                     <div className="border-t border-border mt-2 pt-2">
                       <button


### PR DESCRIPTION
The Help menu link was using <Link> opening tag but </a> closing tag, causing a build error.