### PR TITLE
Add admin scan messages management page

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -478,3 +478,73 @@ model AuthErrorSummary {
 
   @@index([dateKey])
 }
+
+// ==========================================
+// SCAN MESSAGES MODELS
+// For managing humorous scan loading messages
+// ==========================================
+
+model ScanMessage {
+  id        String   @id @default(cuid())
+  headline  String   // Main message text
+  subtext   String   // Secondary/supporting text
+  order     Int      // Display order (0-based)
+  isActive  Boolean  @default(true)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  // Track which generation batch this came from
+  generationId String?
+  generation   ScanMessageGeneration? @relation(fields: [generationId], references: [id])
+
+  @@index([isActive, order])
+  @@index([generationId])
+}
+
+model ScanMessageHistory {
+  id        String   @id @default(cuid())
+  headline  String
+  subtext   String
+
+  // Why it was archived
+  archiveReason String?  // REPLACED, DISCARDED, MANUAL_REMOVE
+
+  // Original creation data
+  originalCreatedAt DateTime
+  archivedAt        DateTime @default(now())
+
+  // Track which generation it came from
+  generationId String?
+
+  @@index([archivedAt])
+}
+
+model ScanMessageGeneration {
+  id        String   @id @default(cuid())
+
+  // Generation context
+  prompt         String   @db.Text  // The prompt used
+  model          String             // e.g., gpt-4o-mini
+
+  // Results
+  generatedCount Int               // How many were generated
+  acceptedCount  Int   @default(0) // How many were kept
+  discardedCount Int   @default(0) // How many were discarded
+
+  // Feedback for improvement
+  discardedMessages String? @db.Text  // JSON array of discarded messages with reasons
+  feedbackNotes     String? @db.Text  // Additional notes for next generation
+
+  // Token usage
+  tokensUsed    Int?
+  estimatedCost Float?
+
+  createdAt     DateTime @default(now())
+  createdBy     String?  // Admin user ID who triggered generation
+
+  // Relation to messages created from this generation
+  messages      ScanMessage[]
+
+  @@index([createdAt])
+}

--- a/src/app/admin/scan-messages/page.tsx
+++ b/src/app/admin/scan-messages/page.tsx
@@ -1,0 +1,742 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import AdminLayout from "@/components/admin/AdminLayout";
+import AlertBanner from "@/components/admin/AlertBanner";
+import {
+  MessageSquare,
+  Plus,
+  Sparkles,
+  History,
+  GripVertical,
+  Trash2,
+  Edit2,
+  Check,
+  X,
+  RefreshCw,
+  Clock,
+  ChevronDown,
+  ChevronUp,
+  Undo2,
+  Database,
+} from "lucide-react";
+
+interface ScanMessage {
+  id: string;
+  headline: string;
+  subtext: string;
+  order: number;
+  isActive: boolean;
+  createdAt: string;
+  generationId?: string;
+}
+
+interface HistoryMessage {
+  id: string;
+  headline: string;
+  subtext: string;
+  archiveReason: string;
+  originalCreatedAt: string;
+  archivedAt: string;
+}
+
+interface GeneratedMessage {
+  headline: string;
+  subtext: string;
+  accepted: boolean;
+  reason?: string;
+}
+
+export default function ScanMessagesPage() {
+  const [messages, setMessages] = useState<ScanMessage[]>([]);
+  const [historyMessages, setHistoryMessages] = useState<HistoryMessage[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [success, setSuccess] = useState("");
+  const [daysSinceRegeneration, setDaysSinceRegeneration] = useState<number | null>(null);
+  const [lastGenerationDate, setLastGenerationDate] = useState<string | null>(null);
+
+  // UI state
+  const [showHistory, setShowHistory] = useState(false);
+  const [showAddForm, setShowAddForm] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editHeadline, setEditHeadline] = useState("");
+  const [editSubtext, setEditSubtext] = useState("");
+
+  // New message form
+  const [newHeadline, setNewHeadline] = useState("");
+  const [newSubtext, setNewSubtext] = useState("");
+
+  // Generation state
+  const [generating, setGenerating] = useState(false);
+  const [generatedMessages, setGeneratedMessages] = useState<GeneratedMessage[]>([]);
+  const [generationId, setGenerationId] = useState<string | null>(null);
+  const [showReviewPanel, setShowReviewPanel] = useState(false);
+
+  // Drag state
+  const [draggedId, setDraggedId] = useState<string | null>(null);
+
+  // Seed state
+  const [seeding, setSeeding] = useState(false);
+
+  const fetchMessages = useCallback(async () => {
+    try {
+      const res = await fetch("/api/admin/scan-messages");
+      if (!res.ok) throw new Error("Failed to fetch messages");
+      const data = await res.json();
+      setMessages(data.messages);
+      setDaysSinceRegeneration(data.daysSinceRegeneration);
+      setLastGenerationDate(data.lastGenerationDate);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load messages");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const fetchHistory = async () => {
+    try {
+      const res = await fetch("/api/admin/scan-messages/history");
+      if (!res.ok) throw new Error("Failed to fetch history");
+      const data = await res.json();
+      setHistoryMessages(data.messages);
+    } catch (err) {
+      console.error("Failed to fetch history:", err);
+    }
+  };
+
+  useEffect(() => {
+    fetchMessages();
+  }, [fetchMessages]);
+
+  useEffect(() => {
+    if (showHistory) {
+      fetchHistory();
+    }
+  }, [showHistory]);
+
+  // Clear success message after 3 seconds
+  useEffect(() => {
+    if (success) {
+      const timer = setTimeout(() => setSuccess(""), 3000);
+      return () => clearTimeout(timer);
+    }
+  }, [success]);
+
+  const handleAddMessage = async () => {
+    if (!newHeadline.trim() || !newSubtext.trim()) return;
+
+    try {
+      const res = await fetch("/api/admin/scan-messages", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ headline: newHeadline, subtext: newSubtext }),
+      });
+
+      if (!res.ok) throw new Error("Failed to add message");
+
+      setNewHeadline("");
+      setNewSubtext("");
+      setShowAddForm(false);
+      setSuccess("Message added successfully");
+      fetchMessages();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to add message");
+    }
+  };
+
+  const handleUpdateMessage = async (id: string) => {
+    try {
+      const res = await fetch("/api/admin/scan-messages", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ id, headline: editHeadline, subtext: editSubtext }),
+      });
+
+      if (!res.ok) throw new Error("Failed to update message");
+
+      setEditingId(null);
+      setSuccess("Message updated successfully");
+      fetchMessages();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to update message");
+    }
+  };
+
+  const handleDeleteMessage = async (id: string) => {
+    if (!confirm("Are you sure you want to remove this message?")) return;
+
+    try {
+      const res = await fetch(`/api/admin/scan-messages?id=${id}`, {
+        method: "DELETE",
+      });
+
+      if (!res.ok) throw new Error("Failed to delete message");
+
+      setSuccess("Message removed and archived");
+      fetchMessages();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to delete message");
+    }
+  };
+
+  const handleRestoreMessage = async (historyId: string) => {
+    try {
+      const res = await fetch("/api/admin/scan-messages/history", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ historyId }),
+      });
+
+      if (!res.ok) throw new Error("Failed to restore message");
+
+      setSuccess("Message restored successfully");
+      fetchMessages();
+      fetchHistory();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to restore message");
+    }
+  };
+
+  const handleGenerateMessages = async () => {
+    setGenerating(true);
+    setError("");
+
+    try {
+      const res = await fetch("/api/admin/scan-messages/generate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ count: 15 }),
+      });
+
+      if (!res.ok) throw new Error("Failed to generate messages");
+
+      const data = await res.json();
+      setGeneratedMessages(
+        data.messages.map((m: { headline: string; subtext: string }) => ({
+          ...m,
+          accepted: true, // Default to accepted
+          reason: "",
+        }))
+      );
+      setGenerationId(data.generationId);
+      setShowReviewPanel(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to generate messages");
+    } finally {
+      setGenerating(false);
+    }
+  };
+
+  const handleToggleAccept = (index: number) => {
+    setGeneratedMessages((prev) =>
+      prev.map((m, i) => (i === index ? { ...m, accepted: !m.accepted } : m))
+    );
+  };
+
+  const handleSetRejectionReason = (index: number, reason: string) => {
+    setGeneratedMessages((prev) =>
+      prev.map((m, i) => (i === index ? { ...m, reason } : m))
+    );
+  };
+
+  const handleSubmitReview = async () => {
+    if (!generationId) return;
+
+    try {
+      const res = await fetch("/api/admin/scan-messages/review", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          generationId,
+          messages: generatedMessages,
+        }),
+      });
+
+      if (!res.ok) throw new Error("Failed to submit review");
+
+      const data = await res.json();
+      setSuccess(`Added ${data.accepted} messages, rejected ${data.rejected}`);
+      setShowReviewPanel(false);
+      setGeneratedMessages([]);
+      setGenerationId(null);
+      fetchMessages();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to submit review");
+    }
+  };
+
+  // Drag and drop handlers
+  const handleDragStart = (e: React.DragEvent, id: string) => {
+    setDraggedId(id);
+    e.dataTransfer.effectAllowed = "move";
+  };
+
+  const handleDragOver = (e: React.DragEvent) => {
+    e.preventDefault();
+    e.dataTransfer.dropEffect = "move";
+  };
+
+  const handleDrop = async (e: React.DragEvent, targetId: string) => {
+    e.preventDefault();
+    if (!draggedId || draggedId === targetId) return;
+
+    const draggedIndex = messages.findIndex((m) => m.id === draggedId);
+    const targetIndex = messages.findIndex((m) => m.id === targetId);
+
+    if (draggedIndex === -1 || targetIndex === -1) return;
+
+    // Reorder locally first for instant feedback
+    const newMessages = [...messages];
+    const [removed] = newMessages.splice(draggedIndex, 1);
+    newMessages.splice(targetIndex, 0, removed);
+    setMessages(newMessages);
+
+    // Save to server
+    try {
+      const res = await fetch("/api/admin/scan-messages/reorder", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ messageIds: newMessages.map((m) => m.id) }),
+      });
+
+      if (!res.ok) throw new Error("Failed to save order");
+      setSuccess("Order updated");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save order");
+      fetchMessages(); // Revert on error
+    }
+
+    setDraggedId(null);
+  };
+
+  const startEditing = (message: ScanMessage) => {
+    setEditingId(message.id);
+    setEditHeadline(message.headline);
+    setEditSubtext(message.subtext);
+  };
+
+  const handleSeedDefaults = async () => {
+    if (!confirm("This will add all default taglines to the database. Continue?")) return;
+
+    setSeeding(true);
+    setError("");
+
+    try {
+      const res = await fetch("/api/admin/scan-messages/seed", {
+        method: "POST",
+      });
+
+      const data = await res.json();
+
+      if (!res.ok) {
+        throw new Error(data.error || "Failed to seed messages");
+      }
+
+      setSuccess(`Successfully added ${data.count} default messages`);
+      fetchMessages();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to seed messages");
+    } finally {
+      setSeeding(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <AdminLayout>
+        <div className="animate-pulse space-y-6">
+          <div className="h-8 bg-gray-200 rounded w-1/4" />
+          <div className="space-y-4">
+            {[1, 2, 3, 4, 5].map((i) => (
+              <div key={i} className="h-20 bg-gray-200 rounded" />
+            ))}
+          </div>
+        </div>
+      </AdminLayout>
+    );
+  }
+
+  return (
+    <AdminLayout>
+      <div className="space-y-6">
+        {/* Header */}
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900 flex items-center gap-2">
+              <MessageSquare className="h-6 w-6 text-indigo-600" />
+              Scan Messages
+            </h1>
+            <p className="mt-1 text-sm text-gray-500">
+              Manage the rotating messages shown during scans
+            </p>
+          </div>
+
+          {/* Days since regeneration badge */}
+          {daysSinceRegeneration !== null && (
+            <div
+              className={`flex items-center gap-2 px-4 py-2 rounded-lg ${
+                daysSinceRegeneration > 30
+                  ? "bg-red-100 text-red-800"
+                  : daysSinceRegeneration > 14
+                  ? "bg-yellow-100 text-yellow-800"
+                  : "bg-green-100 text-green-800"
+              }`}
+            >
+              <Clock className="h-4 w-4" />
+              <span className="text-sm font-medium">
+                {daysSinceRegeneration === 0
+                  ? "Generated today"
+                  : `${daysSinceRegeneration} day${daysSinceRegeneration !== 1 ? "s" : ""} since last generation`}
+              </span>
+            </div>
+          )}
+        </div>
+
+        {/* Alerts */}
+        {error && (
+          <AlertBanner type="error" title="Error" message={error} onDismiss={() => setError("")} />
+        )}
+        {success && (
+          <AlertBanner type="success" title="Success" message={success} />
+        )}
+
+        {/* Action Buttons */}
+        <div className="flex gap-3">
+          <button
+            onClick={() => setShowAddForm(!showAddForm)}
+            className="flex items-center gap-2 px-4 py-2 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors"
+          >
+            <Plus className="h-4 w-4" />
+            Add Message
+          </button>
+          <button
+            onClick={handleGenerateMessages}
+            disabled={generating}
+            className="flex items-center gap-2 px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          >
+            {generating ? (
+              <RefreshCw className="h-4 w-4 animate-spin" />
+            ) : (
+              <Sparkles className="h-4 w-4" />
+            )}
+            {generating ? "Generating..." : "Generate 15 with AI"}
+          </button>
+          <button
+            onClick={() => setShowHistory(!showHistory)}
+            className="flex items-center gap-2 px-4 py-2 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors"
+          >
+            <History className="h-4 w-4" />
+            {showHistory ? "Hide" : "Show"} History
+            {showHistory ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
+          </button>
+        </div>
+
+        {/* Add New Message Form */}
+        {showAddForm && (
+          <div className="bg-white rounded-lg shadow p-6 border-2 border-indigo-200">
+            <h3 className="text-lg font-medium mb-4">Add New Message</h3>
+            <div className="space-y-4">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Headline
+                </label>
+                <input
+                  type="text"
+                  value={newHeadline}
+                  onChange={(e) => setNewHeadline(e.target.value)}
+                  placeholder="e.g., Let's find the scam before it finds you."
+                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
+                  maxLength={100}
+                />
+                <p className="mt-1 text-xs text-gray-500">{newHeadline.length}/100 characters</p>
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Subtext
+                </label>
+                <input
+                  type="text"
+                  value={newSubtext}
+                  onChange={(e) => setNewSubtext(e.target.value)}
+                  placeholder="e.g., Enter a ticker to check for red flags"
+                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
+                  maxLength={80}
+                />
+                <p className="mt-1 text-xs text-gray-500">{newSubtext.length}/80 characters</p>
+              </div>
+              <div className="flex gap-2">
+                <button
+                  onClick={handleAddMessage}
+                  disabled={!newHeadline.trim() || !newSubtext.trim()}
+                  className="px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                >
+                  Add Message
+                </button>
+                <button
+                  onClick={() => {
+                    setShowAddForm(false);
+                    setNewHeadline("");
+                    setNewSubtext("");
+                  }}
+                  className="px-4 py-2 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors"
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* AI Generation Review Panel */}
+        {showReviewPanel && generatedMessages.length > 0 && (
+          <div className="bg-gradient-to-r from-indigo-50 to-purple-50 rounded-lg shadow-lg p-6 border-2 border-indigo-300">
+            <div className="flex items-center justify-between mb-4">
+              <h3 className="text-lg font-medium flex items-center gap-2">
+                <Sparkles className="h-5 w-5 text-indigo-600" />
+                Review Generated Messages
+              </h3>
+              <span className="text-sm text-gray-600">
+                {generatedMessages.filter((m) => m.accepted).length} of {generatedMessages.length} selected
+              </span>
+            </div>
+            <p className="text-sm text-gray-600 mb-4">
+              Click to toggle selection. Rejected messages will be used as feedback for future generations.
+            </p>
+            <div className="space-y-3 max-h-[500px] overflow-y-auto">
+              {generatedMessages.map((msg, index) => (
+                <div
+                  key={index}
+                  className={`p-4 rounded-lg border-2 transition-all cursor-pointer ${
+                    msg.accepted
+                      ? "bg-white border-green-300 hover:border-green-400"
+                      : "bg-gray-50 border-red-200 hover:border-red-300"
+                  }`}
+                  onClick={() => handleToggleAccept(index)}
+                >
+                  <div className="flex items-start justify-between">
+                    <div className="flex-1">
+                      <p className="font-medium text-gray-900">{msg.headline}</p>
+                      <p className="text-sm text-gray-600 mt-1">{msg.subtext}</p>
+                    </div>
+                    <div
+                      className={`ml-4 p-2 rounded-full ${
+                        msg.accepted ? "bg-green-100 text-green-600" : "bg-red-100 text-red-600"
+                      }`}
+                    >
+                      {msg.accepted ? <Check className="h-5 w-5" /> : <X className="h-5 w-5" />}
+                    </div>
+                  </div>
+                  {!msg.accepted && (
+                    <div className="mt-3" onClick={(e) => e.stopPropagation()}>
+                      <input
+                        type="text"
+                        value={msg.reason || ""}
+                        onChange={(e) => handleSetRejectionReason(index, e.target.value)}
+                        placeholder="Why was this rejected? (optional, helps improve future generations)"
+                        className="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-red-500 focus:border-transparent"
+                      />
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+            <div className="flex gap-3 mt-6">
+              <button
+                onClick={handleSubmitReview}
+                className="px-6 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition-colors"
+              >
+                Save Selected ({generatedMessages.filter((m) => m.accepted).length})
+              </button>
+              <button
+                onClick={() => {
+                  setShowReviewPanel(false);
+                  setGeneratedMessages([]);
+                  setGenerationId(null);
+                }}
+                className="px-6 py-2 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors"
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* Active Messages List */}
+        <div className="bg-white rounded-lg shadow">
+          <div className="px-6 py-4 border-b border-gray-200">
+            <h3 className="text-lg font-medium text-gray-900">
+              Active Messages ({messages.length})
+            </h3>
+            <p className="text-sm text-gray-500 mt-1">
+              Drag and drop to reorder. These messages rotate during scans.
+            </p>
+          </div>
+          <div className="divide-y divide-gray-200">
+            {messages.length === 0 ? (
+              <div className="p-8 text-center">
+                <p className="text-gray-500 mb-4">
+                  No messages yet. Add some, generate with AI, or seed with defaults.
+                </p>
+                <button
+                  onClick={handleSeedDefaults}
+                  disabled={seeding}
+                  className="flex items-center gap-2 px-4 py-2 bg-gray-600 text-white rounded-lg hover:bg-gray-700 disabled:opacity-50 transition-colors mx-auto"
+                >
+                  <Database className="h-4 w-4" />
+                  {seeding ? "Loading..." : "Load Default Messages"}
+                </button>
+              </div>
+            ) : (
+              messages.map((message) => (
+                <div
+                  key={message.id}
+                  draggable={editingId !== message.id}
+                  onDragStart={(e) => handleDragStart(e, message.id)}
+                  onDragOver={handleDragOver}
+                  onDrop={(e) => handleDrop(e, message.id)}
+                  className={`p-4 flex items-center gap-4 transition-colors ${
+                    draggedId === message.id
+                      ? "bg-indigo-50 opacity-50"
+                      : "hover:bg-gray-50"
+                  }`}
+                >
+                  <div className="cursor-grab text-gray-400 hover:text-gray-600">
+                    <GripVertical className="h-5 w-5" />
+                  </div>
+                  <div className="flex-shrink-0 w-8 h-8 rounded-full bg-indigo-100 text-indigo-600 flex items-center justify-center text-sm font-medium">
+                    {message.order + 1}
+                  </div>
+
+                  {editingId === message.id ? (
+                    <div className="flex-1 space-y-2">
+                      <input
+                        type="text"
+                        value={editHeadline}
+                        onChange={(e) => setEditHeadline(e.target.value)}
+                        className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
+                      />
+                      <input
+                        type="text"
+                        value={editSubtext}
+                        onChange={(e) => setEditSubtext(e.target.value)}
+                        className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
+                      />
+                      <div className="flex gap-2">
+                        <button
+                          onClick={() => handleUpdateMessage(message.id)}
+                          className="px-3 py-1 bg-green-600 text-white rounded hover:bg-green-700"
+                        >
+                          Save
+                        </button>
+                        <button
+                          onClick={() => setEditingId(null)}
+                          className="px-3 py-1 border border-gray-300 rounded hover:bg-gray-50"
+                        >
+                          Cancel
+                        </button>
+                      </div>
+                    </div>
+                  ) : (
+                    <>
+                      <div className="flex-1 min-w-0">
+                        <p className="font-medium text-gray-900 truncate">
+                          {message.headline}
+                        </p>
+                        <p className="text-sm text-gray-500 truncate">{message.subtext}</p>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <button
+                          onClick={() => startEditing(message)}
+                          className="p-2 text-gray-400 hover:text-indigo-600 transition-colors"
+                          title="Edit"
+                        >
+                          <Edit2 className="h-4 w-4" />
+                        </button>
+                        <button
+                          onClick={() => handleDeleteMessage(message.id)}
+                          className="p-2 text-gray-400 hover:text-red-600 transition-colors"
+                          title="Remove"
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </button>
+                      </div>
+                    </>
+                  )}
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+
+        {/* History Panel */}
+        {showHistory && (
+          <div className="bg-white rounded-lg shadow">
+            <div className="px-6 py-4 border-b border-gray-200">
+              <h3 className="text-lg font-medium text-gray-900 flex items-center gap-2">
+                <History className="h-5 w-5 text-gray-500" />
+                Message History ({historyMessages.length})
+              </h3>
+              <p className="text-sm text-gray-500 mt-1">
+                Previously removed or rejected messages. Click restore to bring one back.
+              </p>
+            </div>
+            <div className="divide-y divide-gray-200 max-h-[400px] overflow-y-auto">
+              {historyMessages.length === 0 ? (
+                <div className="p-8 text-center text-gray-500">
+                  No historical messages yet.
+                </div>
+              ) : (
+                historyMessages.map((message) => (
+                  <div key={message.id} className="p-4 flex items-center gap-4">
+                    <div className="flex-1 min-w-0">
+                      <p className="font-medium text-gray-700">{message.headline}</p>
+                      <p className="text-sm text-gray-500">{message.subtext}</p>
+                      <p className="text-xs text-gray-400 mt-1">
+                        {message.archiveReason === "DISCARDED"
+                          ? "Rejected during review"
+                          : message.archiveReason === "MANUAL_REMOVE"
+                          ? "Manually removed"
+                          : "Replaced"}{" "}
+                        on {new Date(message.archivedAt).toLocaleDateString()}
+                      </p>
+                    </div>
+                    <button
+                      onClick={() => handleRestoreMessage(message.id)}
+                      className="flex items-center gap-1 px-3 py-1 text-sm border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors"
+                    >
+                      <Undo2 className="h-3 w-3" />
+                      Restore
+                    </button>
+                  </div>
+                ))
+              )}
+            </div>
+          </div>
+        )}
+
+        {/* Info panel */}
+        <div className="bg-blue-50 rounded-lg p-4 border border-blue-200">
+          <h4 className="font-medium text-blue-900 mb-2">How this works</h4>
+          <ul className="text-sm text-blue-800 space-y-1">
+            <li>
+              • <strong>Active messages</strong> rotate on the home page and during scans
+            </li>
+            <li>
+              • <strong>Drag and drop</strong> to change the display order
+            </li>
+            <li>
+              • <strong>Generate with AI</strong> creates 15 new messages using GPT-4
+            </li>
+            <li>
+              • <strong>Rejected messages</strong> help improve future AI generations
+            </li>
+            <li>
+              • The <strong>timer</strong> shows how long since new content was added
+            </li>
+          </ul>
+        </div>
+      </div>
+    </AdminLayout>
+  );
+}

--- a/src/app/api/admin/scan-messages/generate/route.ts
+++ b/src/app/api/admin/scan-messages/generate/route.ts
@@ -1,0 +1,204 @@
+/**
+ * Admin Scan Messages Generate API
+ * Uses OpenAI to generate new scan messages
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { getAdminSession } from "@/lib/admin/auth";
+import { prisma } from "@/lib/db";
+import { config } from "@/lib/config";
+import { logApiUsage } from "@/lib/admin/metrics";
+import OpenAI from "openai";
+
+// POST - Generate new messages using AI
+export async function POST(request: NextRequest) {
+  try {
+    const session = await getAdminSession();
+    if (!session) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    if (!config.openaiApiKey) {
+      return NextResponse.json(
+        { error: "OpenAI API key is not configured" },
+        { status: 500 }
+      );
+    }
+
+    const body = await request.json();
+    const { count = 15 } = body;
+
+    // Get existing messages for context (avoid duplicates)
+    const existingMessages = await prisma.scanMessage.findMany({
+      where: { isActive: true },
+      select: { headline: true, subtext: true },
+    });
+
+    // Get recent discarded feedback to improve generation
+    const recentGenerations = await prisma.scanMessageGeneration.findMany({
+      orderBy: { createdAt: "desc" },
+      take: 5,
+      where: {
+        discardedMessages: { not: null },
+      },
+      select: {
+        discardedMessages: true,
+        feedbackNotes: true,
+      },
+    });
+
+    // Build feedback context
+    const feedbackContext = recentGenerations
+      .filter((g) => g.discardedMessages)
+      .map((g) => {
+        try {
+          return JSON.parse(g.discardedMessages as string);
+        } catch {
+          return [];
+        }
+      })
+      .flat();
+
+    const openai = new OpenAI({ apiKey: config.openaiApiKey });
+    const apiStartTime = Date.now();
+
+    const prompt = buildGenerationPrompt(count, existingMessages, feedbackContext);
+
+    const response = await openai.chat.completions.create({
+      model: "gpt-4o-mini",
+      messages: [
+        {
+          role: "system",
+          content: `You are a creative copywriter for ScamDunk, a financial scam detection app. Your job is to write witty, engaging, and slightly humorous loading messages that keep users entertained while their stock analysis runs.
+
+STYLE GUIDELINES:
+- Be clever and witty, but not cheesy
+- Light humor is good, but don't be offensive or insensitive about financial losses
+- Messages should be about stock scams, investing, or financial vigilance
+- Keep headlines punchy (under 60 characters ideally)
+- Subtexts should be supportive and action-oriented (under 50 characters ideally)
+- Vary the tone: some can be playful, some more serious but still engaging
+- Reference common scam tactics (guaranteed returns, hot tips, time pressure)
+- Use relatable scenarios (uncle's stock tip, friend's "sure thing")
+
+AVOID:
+- Being preachy or condescending
+- Making fun of people who got scammed
+- Anything that could be financial advice
+- Generic boring messages
+- Repeating the same joke structure`,
+        },
+        {
+          role: "user",
+          content: prompt,
+        },
+      ],
+      temperature: 0.8, // Higher creativity for variety
+      response_format: { type: "json_object" },
+    });
+
+    const responseTime = Date.now() - apiStartTime;
+    const tokensUsed = response.usage?.total_tokens || 0;
+    const estimatedCost = tokensUsed * 0.0000003;
+
+    // Log API usage
+    await logApiUsage({
+      service: "OPENAI",
+      endpoint: "chat/completions (scan-messages)",
+      tokensUsed,
+      estimatedCost,
+      responseTime,
+      statusCode: 200,
+    });
+
+    const content = response.choices[0]?.message?.content;
+    if (!content) {
+      throw new Error("No content in OpenAI response");
+    }
+
+    const parsed = JSON.parse(content);
+    const generatedMessages = parsed.messages as Array<{
+      headline: string;
+      subtext: string;
+    }>;
+
+    if (!Array.isArray(generatedMessages) || generatedMessages.length === 0) {
+      throw new Error("Invalid response format from LLM");
+    }
+
+    // Create generation record
+    const generation = await prisma.scanMessageGeneration.create({
+      data: {
+        prompt,
+        model: "gpt-4o-mini",
+        generatedCount: generatedMessages.length,
+        tokensUsed,
+        estimatedCost,
+        createdBy: session.id,
+      },
+    });
+
+    // Log the action
+    await prisma.adminAuditLog.create({
+      data: {
+        adminUserId: session.id,
+        action: "SCAN_MESSAGES_GENERATED",
+        resource: generation.id,
+        details: JSON.stringify({ count: generatedMessages.length }),
+      },
+    });
+
+    return NextResponse.json({
+      generationId: generation.id,
+      messages: generatedMessages,
+      tokensUsed,
+      estimatedCost,
+    });
+  } catch (error) {
+    console.error("Generate scan messages error:", error);
+    return NextResponse.json(
+      { error: "Failed to generate scan messages" },
+      { status: 500 }
+    );
+  }
+}
+
+function buildGenerationPrompt(
+  count: number,
+  existingMessages: Array<{ headline: string; subtext: string }>,
+  feedbackContext: Array<{ headline: string; subtext: string; reason?: string }>
+): string {
+  let prompt = `Generate ${count} new loading screen messages for our financial scam detection app.
+
+Each message needs:
+- headline: The main catchy phrase (max 60 chars)
+- subtext: Supporting action-oriented text (max 50 chars)
+
+`;
+
+  if (existingMessages.length > 0) {
+    prompt += `EXISTING MESSAGES (do not duplicate these themes):
+${existingMessages.slice(0, 10).map((m) => `- "${m.headline}"`).join("\n")}
+
+`;
+  }
+
+  if (feedbackContext.length > 0) {
+    prompt += `PREVIOUSLY REJECTED MESSAGES (learn from what didn't work):
+${feedbackContext.slice(0, 10).map((m) => `- "${m.headline}" ${m.reason ? `(Reason: ${m.reason})` : ""}`).join("\n")}
+
+`;
+  }
+
+  prompt += `Return a JSON object with this structure:
+{
+  "messages": [
+    { "headline": "...", "subtext": "..." },
+    ...
+  ]
+}
+
+Generate exactly ${count} unique, creative messages.`;
+
+  return prompt;
+}

--- a/src/app/api/admin/scan-messages/history/route.ts
+++ b/src/app/api/admin/scan-messages/history/route.ts
@@ -1,0 +1,117 @@
+/**
+ * Admin Scan Messages History API
+ * Get archived/historical scan messages
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { getAdminSession } from "@/lib/admin/auth";
+import { prisma } from "@/lib/db";
+
+// GET - List historical scan messages
+export async function GET(request: NextRequest) {
+  try {
+    const session = await getAdminSession();
+    if (!session) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { searchParams } = new URL(request.url);
+    const page = parseInt(searchParams.get("page") || "1");
+    const limit = parseInt(searchParams.get("limit") || "50");
+    const skip = (page - 1) * limit;
+
+    const [messages, totalCount] = await Promise.all([
+      prisma.scanMessageHistory.findMany({
+        orderBy: { archivedAt: "desc" },
+        skip,
+        take: limit,
+      }),
+      prisma.scanMessageHistory.count(),
+    ]);
+
+    return NextResponse.json({
+      messages,
+      totalCount,
+      page,
+      totalPages: Math.ceil(totalCount / limit),
+    });
+  } catch (error) {
+    console.error("Get scan message history error:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch scan message history" },
+      { status: 500 }
+    );
+  }
+}
+
+// POST - Restore a message from history
+export async function POST(request: NextRequest) {
+  try {
+    const session = await getAdminSession();
+    if (!session) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body = await request.json();
+    const { historyId } = body;
+
+    if (!historyId) {
+      return NextResponse.json(
+        { error: "historyId is required" },
+        { status: 400 }
+      );
+    }
+
+    const historyMessage = await prisma.scanMessageHistory.findUnique({
+      where: { id: historyId },
+    });
+
+    if (!historyMessage) {
+      return NextResponse.json(
+        { error: "History message not found" },
+        { status: 404 }
+      );
+    }
+
+    // Get current max order
+    const maxOrderMessage = await prisma.scanMessage.findFirst({
+      where: { isActive: true },
+      orderBy: { order: "desc" },
+    });
+    const newOrder = (maxOrderMessage?.order ?? -1) + 1;
+
+    // Create new active message
+    const restoredMessage = await prisma.scanMessage.create({
+      data: {
+        headline: historyMessage.headline,
+        subtext: historyMessage.subtext,
+        order: newOrder,
+        isActive: true,
+        generationId: historyMessage.generationId,
+      },
+    });
+
+    // Remove from history
+    await prisma.scanMessageHistory.delete({
+      where: { id: historyId },
+    });
+
+    // Log the action
+    await prisma.adminAuditLog.create({
+      data: {
+        adminUserId: session.id,
+        action: "SCAN_MESSAGE_RESTORED",
+        resource: restoredMessage.id,
+        details: JSON.stringify({ headline: restoredMessage.headline }),
+      },
+    });
+
+    return NextResponse.json(restoredMessage);
+  } catch (error) {
+    console.error("Restore scan message error:", error);
+    return NextResponse.json(
+      { error: "Failed to restore scan message" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/admin/scan-messages/reorder/route.ts
+++ b/src/app/api/admin/scan-messages/reorder/route.ts
@@ -1,0 +1,55 @@
+/**
+ * Admin Scan Messages Reorder API
+ * Handles drag-and-drop reordering of scan messages
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { getAdminSession } from "@/lib/admin/auth";
+import { prisma } from "@/lib/db";
+
+// POST - Reorder messages
+export async function POST(request: NextRequest) {
+  try {
+    const session = await getAdminSession();
+    if (!session) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body = await request.json();
+    const { messageIds } = body;
+
+    if (!Array.isArray(messageIds) || messageIds.length === 0) {
+      return NextResponse.json(
+        { error: "messageIds array is required" },
+        { status: 400 }
+      );
+    }
+
+    // Update order for each message
+    await prisma.$transaction(
+      messageIds.map((id: string, index: number) =>
+        prisma.scanMessage.update({
+          where: { id },
+          data: { order: index },
+        })
+      )
+    );
+
+    // Log the action
+    await prisma.adminAuditLog.create({
+      data: {
+        adminUserId: session.id,
+        action: "SCAN_MESSAGES_REORDERED",
+        details: JSON.stringify({ newOrder: messageIds }),
+      },
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("Reorder scan messages error:", error);
+    return NextResponse.json(
+      { error: "Failed to reorder scan messages" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/admin/scan-messages/review/route.ts
+++ b/src/app/api/admin/scan-messages/review/route.ts
@@ -1,0 +1,132 @@
+/**
+ * Admin Scan Messages Review API
+ * Accept or reject generated messages with feedback
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { getAdminSession } from "@/lib/admin/auth";
+import { prisma } from "@/lib/db";
+
+interface ReviewedMessage {
+  headline: string;
+  subtext: string;
+  accepted: boolean;
+  reason?: string; // Reason for rejection
+}
+
+// POST - Submit review of generated messages
+export async function POST(request: NextRequest) {
+  try {
+    const session = await getAdminSession();
+    if (!session) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body = await request.json();
+    const { generationId, messages, feedbackNotes } = body as {
+      generationId: string;
+      messages: ReviewedMessage[];
+      feedbackNotes?: string;
+    };
+
+    if (!generationId || !Array.isArray(messages)) {
+      return NextResponse.json(
+        { error: "generationId and messages array are required" },
+        { status: 400 }
+      );
+    }
+
+    // Verify generation exists
+    const generation = await prisma.scanMessageGeneration.findUnique({
+      where: { id: generationId },
+    });
+
+    if (!generation) {
+      return NextResponse.json(
+        { error: "Generation not found" },
+        { status: 404 }
+      );
+    }
+
+    const acceptedMessages = messages.filter((m) => m.accepted);
+    const rejectedMessages = messages.filter((m) => !m.accepted);
+
+    // Get current max order for new messages
+    const maxOrderMessage = await prisma.scanMessage.findFirst({
+      where: { isActive: true },
+      orderBy: { order: "desc" },
+    });
+    let nextOrder = (maxOrderMessage?.order ?? -1) + 1;
+
+    // Create accepted messages as active
+    const createdMessages = [];
+    for (const msg of acceptedMessages) {
+      const created = await prisma.scanMessage.create({
+        data: {
+          headline: msg.headline,
+          subtext: msg.subtext,
+          order: nextOrder++,
+          isActive: true,
+          generationId,
+        },
+      });
+      createdMessages.push(created);
+    }
+
+    // Archive rejected messages to history for future reference
+    for (const msg of rejectedMessages) {
+      await prisma.scanMessageHistory.create({
+        data: {
+          headline: msg.headline,
+          subtext: msg.subtext,
+          archiveReason: "DISCARDED",
+          originalCreatedAt: generation.createdAt,
+          generationId,
+        },
+      });
+    }
+
+    // Update generation record with feedback
+    await prisma.scanMessageGeneration.update({
+      where: { id: generationId },
+      data: {
+        acceptedCount: acceptedMessages.length,
+        discardedCount: rejectedMessages.length,
+        discardedMessages: JSON.stringify(
+          rejectedMessages.map((m) => ({
+            headline: m.headline,
+            subtext: m.subtext,
+            reason: m.reason || "Not specified",
+          }))
+        ),
+        feedbackNotes: feedbackNotes || null,
+      },
+    });
+
+    // Log the action
+    await prisma.adminAuditLog.create({
+      data: {
+        adminUserId: session.id,
+        action: "SCAN_MESSAGES_REVIEWED",
+        resource: generationId,
+        details: JSON.stringify({
+          accepted: acceptedMessages.length,
+          rejected: rejectedMessages.length,
+        }),
+      },
+    });
+
+    return NextResponse.json({
+      success: true,
+      accepted: acceptedMessages.length,
+      rejected: rejectedMessages.length,
+      newMessages: createdMessages,
+    });
+  } catch (error) {
+    console.error("Review scan messages error:", error);
+    return NextResponse.json(
+      { error: "Failed to review scan messages" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/admin/scan-messages/route.ts
+++ b/src/app/api/admin/scan-messages/route.ts
@@ -1,0 +1,224 @@
+/**
+ * Admin Scan Messages API - CRUD operations for scan messages
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { getAdminSession } from "@/lib/admin/auth";
+import { prisma } from "@/lib/db";
+
+// GET - List all active scan messages
+export async function GET() {
+  try {
+    const session = await getAdminSession();
+    if (!session) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const messages = await prisma.scanMessage.findMany({
+      where: { isActive: true },
+      orderBy: { order: "asc" },
+      include: {
+        generation: {
+          select: {
+            id: true,
+            createdAt: true,
+          },
+        },
+      },
+    });
+
+    // Get the last generation date
+    const lastGeneration = await prisma.scanMessageGeneration.findFirst({
+      orderBy: { createdAt: "desc" },
+    });
+
+    // Calculate days since last regeneration
+    const daysSinceRegeneration = lastGeneration
+      ? Math.floor(
+          (Date.now() - lastGeneration.createdAt.getTime()) / (1000 * 60 * 60 * 24)
+        )
+      : null;
+
+    return NextResponse.json({
+      messages,
+      lastGenerationDate: lastGeneration?.createdAt || null,
+      daysSinceRegeneration,
+      totalCount: messages.length,
+    });
+  } catch (error) {
+    console.error("Get scan messages error:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch scan messages" },
+      { status: 500 }
+    );
+  }
+}
+
+// POST - Create a new scan message manually
+export async function POST(request: NextRequest) {
+  try {
+    const session = await getAdminSession();
+    if (!session) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body = await request.json();
+    const { headline, subtext } = body;
+
+    if (!headline || !subtext) {
+      return NextResponse.json(
+        { error: "Headline and subtext are required" },
+        { status: 400 }
+      );
+    }
+
+    // Get current max order
+    const maxOrderMessage = await prisma.scanMessage.findFirst({
+      where: { isActive: true },
+      orderBy: { order: "desc" },
+    });
+    const newOrder = (maxOrderMessage?.order ?? -1) + 1;
+
+    const message = await prisma.scanMessage.create({
+      data: {
+        headline,
+        subtext,
+        order: newOrder,
+        isActive: true,
+      },
+    });
+
+    // Log the action
+    await prisma.adminAuditLog.create({
+      data: {
+        adminUserId: session.id,
+        action: "SCAN_MESSAGE_CREATED",
+        resource: message.id,
+        details: JSON.stringify({ headline, subtext }),
+      },
+    });
+
+    return NextResponse.json(message, { status: 201 });
+  } catch (error) {
+    console.error("Create scan message error:", error);
+    return NextResponse.json(
+      { error: "Failed to create scan message" },
+      { status: 500 }
+    );
+  }
+}
+
+// PUT - Update a scan message
+export async function PUT(request: NextRequest) {
+  try {
+    const session = await getAdminSession();
+    if (!session) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body = await request.json();
+    const { id, headline, subtext } = body;
+
+    if (!id) {
+      return NextResponse.json({ error: "Message ID is required" }, { status: 400 });
+    }
+
+    const message = await prisma.scanMessage.update({
+      where: { id },
+      data: {
+        ...(headline && { headline }),
+        ...(subtext && { subtext }),
+      },
+    });
+
+    // Log the action
+    await prisma.adminAuditLog.create({
+      data: {
+        adminUserId: session.id,
+        action: "SCAN_MESSAGE_UPDATED",
+        resource: message.id,
+        details: JSON.stringify({ headline, subtext }),
+      },
+    });
+
+    return NextResponse.json(message);
+  } catch (error) {
+    console.error("Update scan message error:", error);
+    return NextResponse.json(
+      { error: "Failed to update scan message" },
+      { status: 500 }
+    );
+  }
+}
+
+// DELETE - Archive a scan message
+export async function DELETE(request: NextRequest) {
+  try {
+    const session = await getAdminSession();
+    if (!session) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { searchParams } = new URL(request.url);
+    const id = searchParams.get("id");
+
+    if (!id) {
+      return NextResponse.json({ error: "Message ID is required" }, { status: 400 });
+    }
+
+    const message = await prisma.scanMessage.findUnique({
+      where: { id },
+    });
+
+    if (!message) {
+      return NextResponse.json({ error: "Message not found" }, { status: 404 });
+    }
+
+    // Archive the message to history
+    await prisma.scanMessageHistory.create({
+      data: {
+        headline: message.headline,
+        subtext: message.subtext,
+        archiveReason: "MANUAL_REMOVE",
+        originalCreatedAt: message.createdAt,
+        generationId: message.generationId,
+      },
+    });
+
+    // Delete the active message
+    await prisma.scanMessage.delete({
+      where: { id },
+    });
+
+    // Reorder remaining messages
+    const remainingMessages = await prisma.scanMessage.findMany({
+      where: { isActive: true },
+      orderBy: { order: "asc" },
+    });
+
+    for (let i = 0; i < remainingMessages.length; i++) {
+      await prisma.scanMessage.update({
+        where: { id: remainingMessages[i].id },
+        data: { order: i },
+      });
+    }
+
+    // Log the action
+    await prisma.adminAuditLog.create({
+      data: {
+        adminUserId: session.id,
+        action: "SCAN_MESSAGE_DELETED",
+        resource: id,
+        details: JSON.stringify({ headline: message.headline }),
+      },
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("Delete scan message error:", error);
+    return NextResponse.json(
+      { error: "Failed to delete scan message" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/admin/scan-messages/seed/route.ts
+++ b/src/app/api/admin/scan-messages/seed/route.ts
@@ -1,0 +1,80 @@
+/**
+ * Admin Scan Messages Seed API
+ * Seeds the database with default taglines from the static file
+ */
+
+import { NextResponse } from "next/server";
+import { getAdminSession } from "@/lib/admin/auth";
+import { prisma } from "@/lib/db";
+import { taglines } from "@/lib/taglines";
+
+// POST - Seed database with default taglines
+export async function POST() {
+  try {
+    const session = await getAdminSession();
+    if (!session) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    // Check if there are already messages in the database
+    const existingCount = await prisma.scanMessage.count();
+
+    if (existingCount > 0) {
+      return NextResponse.json(
+        {
+          error: "Database already has messages. Clear them first if you want to reseed.",
+          existingCount,
+        },
+        { status: 400 }
+      );
+    }
+
+    // Create a generation record for the seed
+    const generation = await prisma.scanMessageGeneration.create({
+      data: {
+        prompt: "Initial seed from static taglines file",
+        model: "static",
+        generatedCount: taglines.length,
+        acceptedCount: taglines.length,
+        createdBy: session.id,
+      },
+    });
+
+    // Insert all default taglines
+    const createdMessages = await Promise.all(
+      taglines.map((tagline, index) =>
+        prisma.scanMessage.create({
+          data: {
+            headline: tagline.headline,
+            subtext: tagline.subtext,
+            order: index,
+            isActive: true,
+            generationId: generation.id,
+          },
+        })
+      )
+    );
+
+    // Log the action
+    await prisma.adminAuditLog.create({
+      data: {
+        adminUserId: session.id,
+        action: "SCAN_MESSAGES_SEEDED",
+        resource: generation.id,
+        details: JSON.stringify({ count: createdMessages.length }),
+      },
+    });
+
+    return NextResponse.json({
+      success: true,
+      count: createdMessages.length,
+      message: `Seeded ${createdMessages.length} default messages`,
+    });
+  } catch (error) {
+    console.error("Seed scan messages error:", error);
+    return NextResponse.json(
+      { error: "Failed to seed scan messages" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/taglines/route.ts
+++ b/src/app/api/taglines/route.ts
@@ -1,0 +1,37 @@
+/**
+ * Public API to fetch scan taglines/messages
+ * Returns taglines from database, with fallback to static defaults
+ */
+
+import { NextResponse } from "next/server";
+import { getTaglinesFromDB, Tagline } from "@/lib/taglines";
+
+// Cache the taglines for 5 minutes to reduce DB calls
+let cachedTaglines: Tagline[] | null = null;
+let cacheTimestamp = 0;
+const CACHE_TTL = 5 * 60 * 1000; // 5 minutes
+
+export async function GET() {
+  try {
+    const now = Date.now();
+
+    // Return cached taglines if still valid
+    if (cachedTaglines && now - cacheTimestamp < CACHE_TTL) {
+      return NextResponse.json({ taglines: cachedTaglines });
+    }
+
+    // Fetch fresh taglines
+    const taglines = await getTaglinesFromDB();
+
+    // Update cache
+    cachedTaglines = taglines;
+    cacheTimestamp = now;
+
+    return NextResponse.json({ taglines });
+  } catch (error) {
+    console.error("Error fetching taglines:", error);
+    // Import static fallback
+    const { taglines: staticTaglines } = await import("@/lib/taglines");
+    return NextResponse.json({ taglines: staticTaglines });
+  }
+}

--- a/src/components/admin/AdminLayout.tsx
+++ b/src/components/admin/AdminLayout.tsx
@@ -19,6 +19,7 @@ import {
   AlertTriangle,
   Search,
   Database,
+  MessageSquare,
 } from "lucide-react";
 
 interface AdminSession {
@@ -30,6 +31,7 @@ interface AdminSession {
 
 const navigation = [
   { name: "Dashboard", href: "/admin/dashboard", icon: LayoutDashboard },
+  { name: "Scan Messages", href: "/admin/scan-messages", icon: MessageSquare },
   { name: "Market Analysis", href: "/admin/market-analysis", icon: TrendingUp },
   { name: "Risk Alerts", href: "/admin/risk-alerts", icon: AlertTriangle },
   { name: "Stock Lookup", href: "/admin/stock-lookup", icon: Search },


### PR DESCRIPTION
This feature adds a comprehensive admin dashboard page for managing the humorous loading messages shown during scans. Features include:

- Database models for ScanMessage, ScanMessageHistory, and ScanMessageGeneration to track active messages, history, and AI generations
- Full CRUD API for managing scan messages
- AI generation endpoint using OpenAI GPT-4o-mini to create 15 new messages at a time with feedback loop for rejected messages
- Drag-and-drop reordering of active messages
- Review panel for accepting/rejecting AI-generated messages
- Message history with restore functionality
- Timer showing days since last AI generation
- Seed functionality to populate DB with default taglines
- Public /api/taglines endpoint with caching for frontend consumption

The admin page is accessible at /admin/scan-messages and includes:
- List of all active messages with inline editing
- AI generation with batch review interface
- Historical messages view with restore option
- Feedback collection for continuous improvement