### PR TITLE
feat(admin): Add email sending for team invite flow

### DIFF
--- a/src/app/admin/team/page.tsx
+++ b/src/app/admin/team/page.tsx
@@ -44,6 +44,7 @@ export default function TeamPage() {
   const [inviteRole, setInviteRole] = useState("ADMIN");
   const [inviting, setInviting] = useState(false);
   const [inviteUrl, setInviteUrl] = useState("");
+  const [emailSent, setEmailSent] = useState(false);
   const [menuOpen, setMenuOpen] = useState<string | null>(null);
 
   useEffect(() => {
@@ -80,7 +81,12 @@ export default function TeamPage() {
       }
 
       setInviteUrl(data.inviteUrl);
-      setSuccess("Invite created successfully!");
+      setEmailSent(data.emailSent || false);
+      setSuccess(
+        data.emailSent
+          ? `Invite email sent to ${inviteEmail}!`
+          : "Invite created! Share the link below with the invitee."
+      );
       fetchTeam();
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to send invite");
@@ -149,6 +155,7 @@ export default function TeamPage() {
               setShowInviteModal(true);
               setInviteUrl("");
               setInviteEmail("");
+              setEmailSent(false);
             }}
             className="inline-flex items-center px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700"
           >
@@ -323,9 +330,17 @@ export default function TeamPage() {
 
               {inviteUrl ? (
                 <div className="space-y-4">
-                  <p className="text-sm text-gray-600">
-                    Share this link with <strong>{inviteEmail}</strong> to complete their registration:
-                  </p>
+                  {emailSent ? (
+                    <div className="bg-green-50 border border-green-200 rounded-md p-3 text-sm text-green-800">
+                      <Check className="h-4 w-4 inline mr-2" />
+                      Invite email sent to <strong>{inviteEmail}</strong>. They can also use the link below:
+                    </div>
+                  ) : (
+                    <div className="bg-amber-50 border border-amber-200 rounded-md p-3 text-sm text-amber-800">
+                      <Mail className="h-4 w-4 inline mr-2" />
+                      Email could not be sent automatically. Share this link with <strong>{inviteEmail}</strong> manually:
+                    </div>
+                  )}
                   <div className="flex items-center space-x-2">
                     <input
                       type="text"

--- a/src/app/api/admin/team/invite/route.ts
+++ b/src/app/api/admin/team/invite/route.ts
@@ -4,6 +4,7 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { getAdminSession, createAdminInvite, acceptAdminInvite } from "@/lib/admin/auth";
+import { sendAdminInviteEmail } from "@/lib/email";
 import { z } from "zod";
 
 export const dynamic = 'force-dynamic';
@@ -46,10 +47,24 @@ export async function POST(request: NextRequest) {
     const baseUrl = process.env.NEXTAUTH_URL || "http://localhost:3000";
     const inviteUrl = `${baseUrl}/admin/login?invite=${result.token}`;
 
+    // Attempt to send invite email
+    let emailSent = false;
+    try {
+      emailSent = await sendAdminInviteEmail(
+        validation.data.email,
+        inviteUrl,
+        validation.data.role,
+        session.name || undefined
+      );
+    } catch (emailError) {
+      console.error("Failed to send invite email:", emailError);
+    }
+
     return NextResponse.json({
       success: true,
       inviteUrl,
       token: result.token,
+      emailSent,
     });
   } catch (error) {
     console.error("Create invite error:", error);

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -269,6 +269,107 @@ export async function sendPasswordResetEmail(email: string, token: string): Prom
 }
 
 /**
+ * Send an admin invite email with a link to join the admin dashboard
+ */
+export async function sendAdminInviteEmail(
+  email: string,
+  inviteUrl: string,
+  role: string,
+  inviterName?: string
+): Promise<boolean> {
+  const config = checkEmailConfiguration();
+  if (config.isTestMode) {
+    console.log(`[EMAIL] Sending admin invite email (TEST MODE - may fail for non-owner emails)`);
+  }
+
+  const roleName = role === 'ADMIN' ? 'Admin' : 'Viewer';
+  const inviterDisplay = inviterName || 'The team owner';
+
+  try {
+    const resend = getResend();
+    const result = await resend.emails.send({
+      from: FROM_EMAIL,
+      to: email,
+      subject: `You're invited to the ScamDunk Admin Dashboard`,
+      html: `
+        <!DOCTYPE html>
+        <html>
+          <head>
+            <meta charset="utf-8">
+            <meta name="viewport" content="width=device-width, initial-scale=1.0">
+          </head>
+          <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
+            <div style="text-align: center; margin-bottom: 30px;">
+              <h1 style="color: #0070f3; margin: 0;">ScamDunk</h1>
+              <p style="color: #666; margin-top: 5px;">Admin Dashboard Invitation</p>
+            </div>
+
+            <div style="background: #f9fafb; border-radius: 8px; padding: 30px; margin-bottom: 20px;">
+              <h2 style="margin-top: 0;">You've been invited!</h2>
+              <p>${inviterDisplay} has invited you to join the ScamDunk Admin Dashboard as a <strong>${roleName}</strong>.</p>
+
+              ${role === 'ADMIN'
+                ? '<p style="color: #666; font-size: 14px;">As an Admin, you\'ll have full access to all dashboard features including scans, lookups, and data analysis.</p>'
+                : '<p style="color: #666; font-size: 14px;">As a Viewer, you\'ll have read-only access to all dashboards and data.</p>'
+              }
+
+              <div style="text-align: center; margin: 30px 0;">
+                <a href="${inviteUrl}" style="background: #4f46e5; color: white; padding: 14px 32px; border-radius: 6px; text-decoration: none; font-weight: 600; display: inline-block; font-size: 16px;">
+                  Accept Invitation
+                </a>
+              </div>
+
+              <p style="color: #666; font-size: 14px;">
+                Or copy and paste this link into your browser:<br>
+                <a href="${inviteUrl}" style="color: #4f46e5; word-break: break-all;">${inviteUrl}</a>
+              </p>
+            </div>
+
+            <p style="color: #666; font-size: 14px;">
+              This invitation expires in 7 days. You'll be asked to set up your name and password when you accept.
+            </p>
+
+            <p style="color: #666; font-size: 14px;">
+              If you weren't expecting this invitation, you can safely ignore this email.
+            </p>
+
+            <hr style="border: none; border-top: 1px solid #eee; margin: 30px 0;">
+
+            <p style="color: #999; font-size: 12px; text-align: center;">
+              ScamDunk - Protecting investors from scams
+            </p>
+          </body>
+        </html>
+      `,
+    });
+
+    if (result.error) {
+      console.error('Resend API error (admin invite):', result.error);
+      const errorMessage = result.error.message?.toLowerCase() || '';
+      if (errorMessage.includes('can only send') || errorMessage.includes('not verified')) {
+        console.error(
+          '[EMAIL ERROR] Resend domain not verified. When using onboarding@resend.dev, ' +
+          'emails can only be sent to the Resend account owner. ' +
+          'Verify a custom domain at https://resend.com/domains'
+        );
+      }
+      return false;
+    }
+
+    console.log('Admin invite email sent successfully to:', email, 'ID:', result.data?.id);
+    return true;
+  } catch (error) {
+    console.error('Failed to send admin invite email:', error);
+    if (error instanceof Error) {
+      if (error.message.includes('API key')) {
+        console.error('[EMAIL ERROR] Invalid or missing RESEND_API_KEY');
+      }
+    }
+    return false;
+  }
+}
+
+/**
  * Send an alert email to the admin when an API failure occurs
  */
 export async function sendAPIFailureAlert(


### PR DESCRIPTION
Previously, the invite system only generated a URL for manual copy-paste. Now it actually sends an invite email via Resend when creating an invite, with graceful fallback to the manual URL sharing if email delivery fails.

- Add sendAdminInviteEmail() function with branded HTML template
- Update invite API route to send email and return emailSent status
- Update team page UI to show email sent confirmation or manual fallback

https://claude.ai/code/session_01TgSMogtp9Q8ASgTafxZsi4