### PR TITLE
fix: make data repository checkout optional when token is missing

### DIFF
--- a/.github/workflows/post-scan-processing.yml
+++ b/.github/workflows/post-scan-processing.yml
@@ -145,6 +145,9 @@ jobs:
           echo "Uploaded $UPLOADED files to Supabase"
 
       - name: Checkout data repository
+        if: ${{ secrets.DATA_REPO_TOKEN != '' }}
+        continue-on-error: true
+        id: checkout-data
         uses: actions/checkout@v4
         with:
           repository: Elimiz21/scam-dunk-data
@@ -152,6 +155,7 @@ jobs:
           path: data-repo
 
       - name: Copy results to data repository
+        if: steps.checkout-data.outcome == 'success'
         env:
           EVALUATION_DATE: ${{ github.event.inputs.evaluation_date }}
         run: |
@@ -170,6 +174,7 @@ jobs:
           find data-repo -name "*${DATE}*" -type f 2>/dev/null | sort
 
       - name: Commit results to data repository
+        if: steps.checkout-data.outcome == 'success'
         env:
           EVALUATION_DATE: ${{ github.event.inputs.evaluation_date }}
         run: |
@@ -186,6 +191,12 @@ jobs:
             git push
             echo "Results pushed to scam-dunk-data repository"
           fi
+
+      - name: Skip data repo notice
+        if: steps.checkout-data.outcome != 'success'
+        run: |
+          echo "::notice::Skipping data repository push - DATA_REPO_TOKEN not configured or invalid"
+          echo "Results are still available as artifacts and uploaded to Supabase"
 
       - name: Upload artifacts
         if: always()

--- a/.github/workflows/real-social-scan.yml
+++ b/.github/workflows/real-social-scan.yml
@@ -91,6 +91,8 @@ jobs:
           done
 
       - name: Checkout data repository
+        continue-on-error: true
+        id: checkout-data
         uses: actions/checkout@v4
         with:
           repository: Elimiz21/scam-dunk-data
@@ -98,6 +100,7 @@ jobs:
           path: data-repo
 
       - name: Copy results to data repository
+        if: steps.checkout-data.outcome == 'success'
         run: |
           mkdir -p data-repo/social-media-scans
           cp evaluation/results/real-social-scan-*.json data-repo/social-media-scans/ 2>/dev/null || true
@@ -107,6 +110,7 @@ jobs:
           ls -la data-repo/social-media-scans/
 
       - name: Commit results
+        if: steps.checkout-data.outcome == 'success'
         run: |
           cd data-repo
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
@@ -121,6 +125,12 @@ jobs:
             git push
             echo "Results pushed to scam-dunk-data repository"
           fi
+
+      - name: Skip data repo notice
+        if: steps.checkout-data.outcome != 'success'
+        run: |
+          echo "::notice::Skipping data repository push - DATA_REPO_TOKEN not configured or invalid"
+          echo "Results are still available as artifacts"
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
The workflows now gracefully handle missing or invalid DATA_REPO_TOKEN by skipping the data repo push steps. Results are still available as artifacts and uploaded to Supabase.

https://claude.ai/code/session_015JyYFVdFHRWwfTHs145mPW