### PR TITLE
fix: repair mailto links for support@scamdunk.com across the site

### DIFF
--- a/src/app/(auth)/error/page.tsx
+++ b/src/app/(auth)/error/page.tsx
@@ -87,9 +87,9 @@ function AuthErrorContent() {
                     </Button>
                     <p className="text-sm text-muted-foreground text-center">
                         Need help?{" "}
-                        <Link href="mailto:support@scamdunk.com" className="text-primary hover:underline">
+                        <a href="mailto:support@scamdunk.com" className="text-primary hover:underline">
                             Contact support
-                        </Link>
+                        </a>
                     </p>
                 </CardFooter>
             </Card>

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -511,10 +511,10 @@ export default function ContactPage() {
                     <div className="p-2 rounded-lg bg-orange-100 dark:bg-orange-900">
                       <Mail className="h-5 w-5 text-orange-600 dark:text-orange-400" />
                     </div>
-                    <h3 className="font-semibold text-orange-900 dark:text-orange-100">Email Support</h3>
+                    <h3 className="font-semibold text-orange-900 dark:text-orange-100">Direct Email</h3>
                   </div>
                   <p className="text-sm text-orange-800/80 dark:text-orange-200/80 mb-2">
-                    Send us an email at:
+                    Prefer to email us directly?
                   </p>
                   <a
                     href="mailto:support@scamdunk.com"
@@ -523,20 +523,6 @@ export default function ContactPage() {
                     <Mail className="h-4 w-4" />
                     support@scamdunk.com
                   </a>
-                  <p className="text-xs text-orange-600/60 dark:text-orange-400/60 mt-2">
-                    Or use the form for faster routing and tracking.
-                  </p>
-                  <button
-                    type="button"
-                    onClick={() => {
-                      document.getElementById("contact-form")?.scrollIntoView({ behavior: "smooth" });
-                      document.getElementById("name")?.focus({ preventScroll: true });
-                    }}
-                    className="mt-2 w-full flex items-center justify-center gap-2 px-4 py-2 rounded-lg bg-orange-100 dark:bg-orange-900 text-orange-800 dark:text-orange-200 text-sm font-medium hover:bg-orange-200 dark:hover:bg-orange-800 transition-colors"
-                  >
-                    <ArrowRight className="h-4 w-4" />
-                    Go to Form
-                  </button>
                 </div>
               </div>
             </div>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -69,9 +69,9 @@ export function Footer() {
             <h4 className="font-semibold mb-3 text-sm">Contact</h4>
             <ul className="space-y-2 text-sm text-muted-foreground">
               <li>
-                <a href="mailto:support@scamdunk.com" className="hover:text-primary transition-colors">
-                  support@scamdunk.com
-                </a>
+                <Link href="/contact" className="hover:text-primary transition-colors">
+                  Contact Support
+                </Link>
               </li>
               <li>
                 <a href="mailto:privacy@scamdunk.com" className="hover:text-primary transition-colors">


### PR DESCRIPTION
- Error page: change Next.js Link to proper <a> tag for mailto (Link breaks mailto protocol)
- Contact page: revert to clean mailto link, remove "Go to Form" button
- Footer: link to /contact page for support instead of broken mailto

https://claude.ai/code/session_0146Jfy43SkraNAkFGgs2mRB