### PR TITLE
fix: replace broken mailto links with functional alternatives

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -252,12 +252,16 @@ export default function AboutPage() {
             {/* Contact */}
             <div className="text-center p-6 rounded-xl bg-card border border-border">
               <h2 className="font-semibold mb-2">Questions?</h2>
-              <p className="text-sm text-muted-foreground mb-2">
-                Reach out at{" "}
-                <a href="mailto:support@scamdunk.com" className="text-primary hover:underline">
-                  support@scamdunk.com
-                </a>
+              <p className="text-sm text-muted-foreground mb-3">
+                We&apos;d love to hear from you.
               </p>
+              <Link
+                href="/contact"
+                className="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl bg-primary text-primary-foreground font-medium hover:opacity-90 transition-opacity text-sm"
+              >
+                <ArrowRight className="h-4 w-4" />
+                Contact Support
+              </Link>
             </div>
           </div>
         </main>

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -101,6 +101,14 @@ export default function ContactPage() {
   const [submitStatus, setSubmitStatus] = useState<"idle" | "success" | "error">("idle");
   const [ticketId, setTicketId] = useState<string | null>(null);
   const [errorMessage, setErrorMessage] = useState<string>("");
+  const [emailCopied, setEmailCopied] = useState(false);
+
+  const handleCopyEmail = () => {
+    navigator.clipboard.writeText("support@scamdunk.com").then(() => {
+      setEmailCopied(true);
+      setTimeout(() => setEmailCopied(false), 2000);
+    });
+  };
 
   const validateForm = (): boolean => {
     const newErrors: FormErrors = {};
@@ -516,13 +524,23 @@ export default function ContactPage() {
                   <p className="text-sm text-orange-800/80 dark:text-orange-200/80 mb-2">
                     Prefer to email us directly?
                   </p>
-                  <a
-                    href="mailto:support@scamdunk.com"
-                    className="text-orange-700 dark:text-orange-300 font-medium hover:underline flex items-center gap-2"
+                  <button
+                    onClick={handleCopyEmail}
+                    className="text-orange-700 dark:text-orange-300 font-medium hover:underline flex items-center gap-2 transition-colors"
+                    title="Copy email address"
                   >
-                    <Mail className="h-4 w-4" />
-                    support@scamdunk.com
-                  </a>
+                    {emailCopied ? (
+                      <>
+                        <CheckCircle className="h-4 w-4 text-green-600" />
+                        <span className="text-green-600">Copied!</span>
+                      </>
+                    ) : (
+                      <>
+                        <Mail className="h-4 w-4" />
+                        support@scamdunk.com
+                      </>
+                    )}
+                  </button>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
- About page: replace mailto with "Contact Support" button linking to /contact
- Contact page: replace mailto with copy-to-clipboard button for email address

mailto: links do nothing on devices without a configured email client. These changes ensure users can always reach support.

https://claude.ai/code/session_0146Jfy43SkraNAkFGgs2mRB