### PR TITLE
Admin dashboard: ERROR_RATE alerts, ingestion diagnostics, backfill & observability

### DIFF
--- a/src/app/admin/dashboard/page.tsx
+++ b/src/app/admin/dashboard/page.tsx
@@ -33,6 +33,7 @@ interface DashboardMetrics {
   newUsersToday: number;
   newUsersThisMonth: number;
   avgProcessingTime: number;
+  lastUpdated: string;
 }
 
 export default function DashboardPage() {
@@ -101,11 +102,16 @@ export default function DashboardPage() {
     <AdminLayout>
       <div className="space-y-6">
         {/* Header */}
-        <div>
-          <h1 className="text-2xl font-bold text-gray-900">Dashboard</h1>
-          <p className="mt-1 text-sm text-gray-500">
-            Overview of Scam Dunk application metrics
-          </p>
+        <div className="flex items-start justify-between">
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900">Dashboard</h1>
+            <p className="mt-1 text-sm text-gray-500">
+              Overview of Scam Dunk application metrics
+            </p>
+          </div>
+          <div className="text-xs text-gray-500">
+            Last Updated: {new Date(metrics.lastUpdated).toLocaleString()}
+          </div>
         </div>
 
         {/* Main Stats */}

--- a/src/app/api/admin/backfill/route.ts
+++ b/src/app/api/admin/backfill/route.ts
@@ -1,0 +1,45 @@
+/**
+ * Admin Backfill API - Rebuild ModelMetrics and ScanUsage from ScanHistory
+ */
+
+import { NextResponse } from "next/server";
+import { getAdminSession, hasRole } from "@/lib/admin/auth";
+import { backfillAdminMetrics } from "@/lib/admin/metrics";
+import { prisma } from "@/lib/db";
+
+export const dynamic = "force-dynamic";
+
+export async function POST() {
+  try {
+    const session = await getAdminSession();
+    if (!session) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    if (!hasRole(session, ["OWNER", "ADMIN"])) {
+      return NextResponse.json({ error: "Insufficient permissions" }, { status: 403 });
+    }
+
+    const result = await backfillAdminMetrics();
+
+    await prisma.adminAuditLog.create({
+      data: {
+        adminUserId: session.id,
+        action: "ADMIN_BACKFILL",
+        details: JSON.stringify(result),
+      },
+    });
+
+    return NextResponse.json({
+      success: true,
+      ...result,
+      lastUpdated: new Date().toISOString(),
+    });
+  } catch (error) {
+    console.error("Backfill error:", error);
+    return NextResponse.json(
+      { error: "Failed to backfill admin metrics", details: String(error) },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/admin/dashboard/route.ts
+++ b/src/app/api/admin/dashboard/route.ts
@@ -17,7 +17,10 @@ export async function GET() {
 
     const metrics = await getDashboardMetrics();
 
-    return NextResponse.json(metrics);
+    return NextResponse.json({
+      ...metrics,
+      lastUpdated: new Date().toISOString(),
+    });
   } catch (error) {
     console.error("Dashboard metrics error:", error);
     return NextResponse.json(

--- a/src/app/api/admin/model-efficacy/feedback/route.ts
+++ b/src/app/api/admin/model-efficacy/feedback/route.ts
@@ -51,14 +51,16 @@ export async function POST(request: NextRequest) {
 
     // Update daily metrics
     if (feedbackType === "FALSE_POSITIVE") {
-      await prisma.modelMetrics.updateMany({
+      await prisma.modelMetrics.upsert({
         where: { dateKey },
-        data: { falsePositives: { increment: 1 } },
+        create: { dateKey, falsePositives: 1 },
+        update: { falsePositives: { increment: 1 } },
       });
     } else if (feedbackType === "FALSE_NEGATIVE") {
-      await prisma.modelMetrics.updateMany({
+      await prisma.modelMetrics.upsert({
         where: { dateKey },
-        data: { falseNegatives: { increment: 1 } },
+        create: { dateKey, falseNegatives: 1 },
+        update: { falseNegatives: { increment: 1 } },
       });
     }
 


### PR DESCRIPTION
### Motivation
- Improve the admin dashboard's reliability and observability by adding missing alert types, richer ingestion diagnostics, and mechanisms to backfill live metrics from historical scans. 
- Ensure model feedback never gets dropped by creating/upserting daily ModelMetrics rows when feedback arrives. 
- Make ingestion failures actionable by surfacing precise error types (missing file, bad JSON, invalid Supabase config, fetch errors) and recording audit logs. 
- Await explicit approval before any production deployment/merge after verification in a real admin session.

### Description
- Implemented ERROR_RATE alert evaluation in `src/lib/admin/metrics.ts` so alerts of type `ERROR_RATE` compute real error percentage from `apiUsageLog` and trigger when threshold is met. 
- Added a `backfillAdminMetrics()` routine in `src/lib/admin/metrics.ts` and a protected admin endpoint `POST /api/admin/backfill` at `src/app/api/admin/backfill/route.ts` that aggregates `ScanHistory` → `ModelMetrics` (daily) and `ScanHistory` → `ScanUsage` (per user/month) via safe upserts. 
- Changed model feedback handler at `src/app/api/admin/model-efficacy/feedback/route.ts` to `upsert` ModelMetrics rows so false positive/negative feedback always increments counts even when a row for that date didn't previously exist. 
- Hardened ingestion flow in `src/app/api/admin/ingest-evaluation/route.ts` to detect and return precise ingestion error types (`MISSING_FILE`, `BAD_JSON`, `INVALID_SUPABASE_CONFIG`, `FETCH_ERROR`), write audit logs on success/failure, and expose `lastIngestion` in the ingest status response. 
- UI updates: added a backfill button and backfill/last-ingestion cards to `src/app/admin/data-ingestion/page.tsx` and added a `Last Updated` timestamp to `src/app/admin/dashboard/page.tsx` driven by `src/app/api/admin/dashboard/route.ts`. 
- Observability: added `logApiUsage()` calls for PayPal in `src/lib/paypal.ts` and instrumented Resend email sends in `src/lib/email.ts` so external services (PayPal, Resend) appear in API usage panels and error/response metrics are recorded. 

### Testing
- Started the dev server with `npm run dev -- --hostname 0.0.0.0 --port 3000`, which compiled and served the app successfully but showed Auth errors because `NEXTAUTH_SECRET` was not configured, blocking full admin login; server start succeeded. 
- Ran an automated Playwright script that opened `http://127.0.0.1:3000/admin/dashboard` and saved a screenshot (`artifacts/admin-dashboard.png`) showing the dashboard page load; the HTTP GET returned `200` for the dashboard route but admin session flows were blocked by missing auth secret. 
- Observability and API changes were exercised indirectly by running the dev server and calling endpoints during the session, and the ingestion endpoint now returns structured errorType and writes `adminAuditLog` entries on success/failure; these code paths executed but full end‑to‑end admin actions (login, triggering ingest/backfill via authenticated UI) could not be completed due to missing auth configuration. 

Automated test summary: `dev` server start - success; Playwright screenshot of `/admin/dashboard` - success; full E2E admin workflows (login/ingest/alert validation) - blocked by missing `NEXTAUTH_SECRET` (configuration), so manual authenticated verification is still required.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69889dfa7aec832c89381e2780f7acf7)