### PR TITLE
fix: force dark text on admin dashboard inputs to fix visibility in d…

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -78,6 +78,18 @@
   }
 }
 
+/* Admin layout: force dark text on all form elements regardless of theme */
+.admin-layout input:not([type="submit"]):not([type="button"]):not([type="reset"]):not([type="file"]),
+.admin-layout textarea,
+.admin-layout select {
+  color: rgb(17 24 39); /* gray-900 */
+}
+
+.admin-layout input::placeholder,
+.admin-layout textarea::placeholder {
+  color: rgb(156 163 175); /* gray-400 */
+}
+
 /* Apple-style animations */
 @keyframes fadeIn {
   from { opacity: 0; transform: translateY(8px); }

--- a/src/components/admin/AdminLayout.tsx
+++ b/src/components/admin/AdminLayout.tsx
@@ -195,7 +195,7 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
   }
 
   return (
-    <div className="min-h-screen bg-gray-100">
+    <div className="admin-layout min-h-screen bg-gray-100 text-gray-900">
       {/* Mobile sidebar overlay */}
       {sidebarOpen && (
         <div


### PR DESCRIPTION
…ark mode

The ThemeProvider sets --foreground to near-white in dark mode, but the admin dashboard uses hardcoded bg-white containers. This caused input text to be invisible (white-on-white). Added text-gray-900 to AdminLayout wrapper and scoped CSS rules for form elements to always use dark text.

https://claude.ai/code/session_019XHB5T7qKtWAW8K13FX62m