### PR TITLE
fix: ensure all admin input fields have visible text (bg-card + text-…

### DIFF
--- a/src/app/admin/api-usage/page.tsx
+++ b/src/app/admin/api-usage/page.tsx
@@ -186,7 +186,7 @@ export default function ApiUsagePage() {
             <select
               value={period}
               onChange={(e) => setPeriod(e.target.value as "day" | "week" | "month")}
-              className="border border-border rounded-md px-3 py-2 text-sm"
+              className="border border-border rounded-md px-3 py-2 text-sm bg-card text-foreground"
             >
               <option value="day">Today</option>
               <option value="week">This Week</option>
@@ -274,7 +274,7 @@ export default function ApiUsagePage() {
                         <select
                           value={newAlert.service}
                           onChange={(e) => setNewAlert({ ...newAlert, service: e.target.value })}
-                          className="mt-1 block w-full border border-border rounded-md px-3 py-2"
+                          className="mt-1 block w-full border border-border rounded-md px-3 py-2 bg-card text-foreground"
                         >
                           <option value="ALL">All Services</option>
                           <option value="OPENAI">OpenAI</option>
@@ -287,7 +287,7 @@ export default function ApiUsagePage() {
                         <select
                           value={newAlert.alertType}
                           onChange={(e) => setNewAlert({ ...newAlert, alertType: e.target.value })}
-                          className="mt-1 block w-full border border-border rounded-md px-3 py-2"
+                          className="mt-1 block w-full border border-border rounded-md px-3 py-2 bg-card text-foreground"
                         >
                           <option value="COST_THRESHOLD">Cost Threshold</option>
                           <option value="RATE_LIMIT">Rate Limit (per hour)</option>
@@ -304,7 +304,7 @@ export default function ApiUsagePage() {
                           onChange={(e) =>
                             setNewAlert({ ...newAlert, threshold: parseFloat(e.target.value) })
                           }
-                          className="mt-1 block w-full border border-border rounded-md px-3 py-2"
+                          className="mt-1 block w-full border border-border rounded-md px-3 py-2 bg-card text-foreground"
                         />
                       </div>
                     </div>

--- a/src/app/admin/email-management/page.tsx
+++ b/src/app/admin/email-management/page.tsx
@@ -594,7 +594,7 @@ export default function EmailManagementPage() {
                       value={testEmail}
                       onChange={(e) => setTestEmail(e.target.value)}
                       placeholder="test@example.com"
-                      className="flex-1 px-3 py-2 border border-primary/20 rounded-md text-sm focus:ring-primary focus:border-primary/50"
+                      className="flex-1 px-3 py-2 border border-primary/20 rounded-md text-sm bg-card text-foreground placeholder:text-muted-foreground focus:ring-primary focus:border-primary/50"
                     />
                     <button
                       onClick={handleSendTestEmail}
@@ -684,7 +684,7 @@ export default function EmailManagementPage() {
                         type="email"
                         value={addForm.email}
                         onChange={(e) => setAddForm({ ...addForm, email: e.target.value })}
-                        className="w-full px-3 py-2 border border-border rounded-md text-sm"
+                        className="w-full px-3 py-2 border border-border rounded-md text-sm bg-card text-foreground placeholder:text-muted-foreground"
                         placeholder="admin@example.com"
                       />
                     </div>
@@ -694,7 +694,7 @@ export default function EmailManagementPage() {
                         type="text"
                         value={addForm.name}
                         onChange={(e) => setAddForm({ ...addForm, name: e.target.value })}
-                        className="w-full px-3 py-2 border border-border rounded-md text-sm"
+                        className="w-full px-3 py-2 border border-border rounded-md text-sm bg-card text-foreground placeholder:text-muted-foreground"
                         placeholder="John Doe"
                       />
                     </div>
@@ -793,7 +793,7 @@ export default function EmailManagementPage() {
                                 type="email"
                                 value={editForm.email}
                                 onChange={(e) => setEditForm({ ...editForm, email: e.target.value })}
-                                className="w-full px-3 py-2 border border-border rounded-md text-sm"
+                                className="w-full px-3 py-2 border border-border rounded-md text-sm bg-card text-foreground placeholder:text-muted-foreground"
                               />
                             </div>
                             <div>
@@ -802,7 +802,7 @@ export default function EmailManagementPage() {
                                 type="text"
                                 value={editForm.name}
                                 onChange={(e) => setEditForm({ ...editForm, name: e.target.value })}
-                                className="w-full px-3 py-2 border border-border rounded-md text-sm"
+                                className="w-full px-3 py-2 border border-border rounded-md text-sm bg-card text-foreground placeholder:text-muted-foreground"
                               />
                             </div>
                           </div>
@@ -959,7 +959,7 @@ export default function EmailManagementPage() {
                     type="email"
                     value={composeForm.to}
                     onChange={(e) => setComposeForm({ ...composeForm, to: e.target.value })}
-                    className="w-full px-3 py-2 border border-border rounded-md text-sm focus:ring-primary focus:border-primary/50"
+                    className="w-full px-3 py-2 border border-border rounded-md text-sm bg-card text-foreground placeholder:text-muted-foreground focus:ring-primary focus:border-primary/50"
                     placeholder="recipient@example.com"
                     required
                   />
@@ -970,7 +970,7 @@ export default function EmailManagementPage() {
                     type="text"
                     value={composeForm.subject}
                     onChange={(e) => setComposeForm({ ...composeForm, subject: e.target.value })}
-                    className="w-full px-3 py-2 border border-border rounded-md text-sm focus:ring-primary focus:border-primary/50"
+                    className="w-full px-3 py-2 border border-border rounded-md text-sm bg-card text-foreground placeholder:text-muted-foreground focus:ring-primary focus:border-primary/50"
                     placeholder="Email subject"
                     required
                   />
@@ -981,7 +981,7 @@ export default function EmailManagementPage() {
                     type="email"
                     value={composeForm.replyTo}
                     onChange={(e) => setComposeForm({ ...composeForm, replyTo: e.target.value })}
-                    className="w-full px-3 py-2 border border-border rounded-md text-sm focus:ring-primary focus:border-primary/50"
+                    className="w-full px-3 py-2 border border-border rounded-md text-sm bg-card text-foreground placeholder:text-muted-foreground focus:ring-primary focus:border-primary/50"
                     placeholder="reply-to@example.com"
                   />
                 </div>
@@ -991,7 +991,7 @@ export default function EmailManagementPage() {
                     value={composeForm.message}
                     onChange={(e) => setComposeForm({ ...composeForm, message: e.target.value })}
                     rows={8}
-                    className="w-full px-3 py-2 border border-border rounded-md text-sm focus:ring-primary focus:border-primary/50"
+                    className="w-full px-3 py-2 border border-border rounded-md text-sm bg-card text-foreground placeholder:text-muted-foreground focus:ring-primary focus:border-primary/50"
                     placeholder="Your email message..."
                     required
                   />
@@ -1037,7 +1037,7 @@ export default function EmailManagementPage() {
                       setLogPagination((p) => ({ ...p, page: 1 }));
                     }}
                     placeholder="Search by email or subject..."
-                    className="w-full pl-10 pr-4 py-2 border border-border rounded-md text-sm"
+                    className="w-full pl-10 pr-4 py-2 border border-border rounded-md text-sm bg-card text-foreground placeholder:text-muted-foreground"
                   />
                 </div>
                 <select
@@ -1046,7 +1046,7 @@ export default function EmailManagementPage() {
                     setLogTypeFilter(e.target.value);
                     setLogPagination((p) => ({ ...p, page: 1 }));
                   }}
-                  className="border border-border rounded-md px-3 py-2 text-sm"
+                  className="border border-border rounded-md px-3 py-2 text-sm bg-card text-foreground"
                 >
                   <option value="">All Types</option>
                   {Object.entries(EMAIL_TYPE_LABELS).map(([key, label]) => (
@@ -1059,7 +1059,7 @@ export default function EmailManagementPage() {
                     setLogStatusFilter(e.target.value);
                     setLogPagination((p) => ({ ...p, page: 1 }));
                   }}
-                  className="border border-border rounded-md px-3 py-2 text-sm"
+                  className="border border-border rounded-md px-3 py-2 text-sm bg-card text-foreground"
                 >
                   <option value="">All Status</option>
                   <option value="SENT">Sent</option>

--- a/src/app/admin/homepage/page.tsx
+++ b/src/app/admin/homepage/page.tsx
@@ -343,7 +343,7 @@ export default function HomepagePage() {
                   value={newHeadline}
                   onChange={(e) => setNewHeadline(e.target.value)}
                   placeholder='e.g., Don&apos;t invest blind. Detect scams before they cost you.'
-                  className="w-full px-3 py-2 border border-border rounded-2xl focus:ring-2 focus:ring-primary focus:border-transparent"
+                  className="w-full px-3 py-2 border border-border rounded-2xl bg-card text-foreground placeholder:text-muted-foreground focus:ring-2 focus:ring-primary focus:border-transparent"
                   maxLength={120}
                 />
                 <p className="mt-1 text-xs text-muted-foreground">
@@ -358,7 +358,7 @@ export default function HomepagePage() {
                   value={newSubheadline}
                   onChange={(e) => setNewSubheadline(e.target.value)}
                   placeholder="e.g., Enter any stock or crypto ticker and get an instant risk analysis..."
-                  className="w-full px-3 py-2 border border-border rounded-2xl focus:ring-2 focus:ring-primary focus:border-transparent"
+                  className="w-full px-3 py-2 border border-border rounded-2xl bg-card text-foreground placeholder:text-muted-foreground focus:ring-2 focus:ring-primary focus:border-transparent"
                   rows={3}
                   maxLength={200}
                 />
@@ -504,7 +504,7 @@ export default function HomepagePage() {
                           type="text"
                           value={editHeadline}
                           onChange={(e) => setEditHeadline(e.target.value)}
-                          className="w-full px-3 py-2 border border-border rounded-2xl focus:ring-2 focus:ring-primary focus:border-transparent"
+                          className="w-full px-3 py-2 border border-border rounded-2xl bg-card text-foreground placeholder:text-muted-foreground focus:ring-2 focus:ring-primary focus:border-transparent"
                           maxLength={120}
                         />
                       </div>
@@ -515,7 +515,7 @@ export default function HomepagePage() {
                         <textarea
                           value={editSubheadline}
                           onChange={(e) => setEditSubheadline(e.target.value)}
-                          className="w-full px-3 py-2 border border-border rounded-2xl focus:ring-2 focus:ring-primary focus:border-transparent"
+                          className="w-full px-3 py-2 border border-border rounded-2xl bg-card text-foreground placeholder:text-muted-foreground focus:ring-2 focus:ring-primary focus:border-transparent"
                           rows={2}
                           maxLength={200}
                         />

--- a/src/app/admin/integrations/page.tsx
+++ b/src/app/admin/integrations/page.tsx
@@ -342,7 +342,7 @@ export default function IntegrationsPage() {
                         monthlyBudget: parseFloat(e.target.value) || null,
                       })
                     }
-                    className="mt-1 block w-full border border-border rounded-md px-3 py-2"
+                    className="mt-1 block w-full border border-border rounded-md px-3 py-2 bg-card text-foreground"
                     placeholder="No limit"
                   />
                 </div>
@@ -359,7 +359,7 @@ export default function IntegrationsPage() {
                         rateLimit: parseInt(e.target.value) || null,
                       })
                     }
-                    className="mt-1 block w-full border border-border rounded-md px-3 py-2"
+                    className="mt-1 block w-full border border-border rounded-md px-3 py-2 bg-card text-foreground"
                   />
                 </div>
                 <p className="text-xs text-muted-foreground">

--- a/src/app/admin/login/page.tsx
+++ b/src/app/admin/login/page.tsx
@@ -154,7 +154,7 @@ function LoginForm() {
                   required
                   value={name}
                   onChange={(e) => setName(e.target.value)}
-                  className="mt-1 block w-full px-3 py-2 bg-secondary border border-border rounded-md text-white placeholder-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
+                  className="mt-1 block w-full px-3 py-2 bg-card border border-border rounded-md text-foreground placeholder-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
                   placeholder="Enter your name"
                 />
               </div>
@@ -169,7 +169,7 @@ function LoginForm() {
                   required
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
-                  className="mt-1 block w-full px-3 py-2 bg-secondary border border-border rounded-md text-white placeholder-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
+                  className="mt-1 block w-full px-3 py-2 bg-card border border-border rounded-md text-foreground placeholder-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
                   placeholder="admin@example.com"
                 />
               </div>
@@ -186,7 +186,7 @@ function LoginForm() {
                   required
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}
-                  className="block w-full px-3 py-2 bg-secondary border border-border rounded-md text-white placeholder-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent pr-10"
+                  className="block w-full px-3 py-2 bg-card border border-border rounded-md text-foreground placeholder-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent pr-10"
                   placeholder={isInviteMode ? "Create a password (min 8 chars)" : "Enter your password"}
                   minLength={isInviteMode ? 8 : undefined}
                 />

--- a/src/app/admin/market-analysis/page.tsx
+++ b/src/app/admin/market-analysis/page.tsx
@@ -117,7 +117,7 @@ export default function MarketAnalysisPage() {
           <select
             value={days}
             onChange={(e) => setDays(parseInt(e.target.value))}
-            className="px-4 py-2 border border-border rounded-md text-sm"
+            className="px-4 py-2 border border-border rounded-md text-sm bg-card text-foreground"
           >
             <option value={7}>Last 7 days</option>
             <option value={30}>Last 30 days</option>

--- a/src/app/admin/model-efficacy/page.tsx
+++ b/src/app/admin/model-efficacy/page.tsx
@@ -226,7 +226,7 @@ export default function ModelEfficacyPage() {
           <select
             value={days}
             onChange={(e) => setDays(parseInt(e.target.value))}
-            className="border border-border rounded-md px-3 py-2 text-sm"
+            className="border border-border rounded-md px-3 py-2 text-sm bg-card text-foreground"
           >
             <option value={7}>Last 7 days</option>
             <option value={30}>Last 30 days</option>
@@ -338,7 +338,7 @@ export default function ModelEfficacyPage() {
                 <select
                   value={filterRisk}
                   onChange={(e) => setFilterRisk(e.target.value)}
-                  className="border border-border rounded-md px-3 py-2 text-sm"
+                  className="border border-border rounded-md px-3 py-2 text-sm bg-card text-foreground"
                 >
                   <option value="">All Risk Levels</option>
                   <option value="LOW">Low Risk</option>

--- a/src/app/admin/news/blog/[id]/page.tsx
+++ b/src/app/admin/news/blog/[id]/page.tsx
@@ -509,7 +509,7 @@ export default function AdminBlogEditorPage() {
                                         type="text"
                                         value={post.title}
                                         onChange={(e) => handleTitleChange(e.target.value)}
-                                        className="w-full px-4 py-2 border border-border rounded-2xl focus:ring-2 focus:ring-primary focus:border-primary/50"
+                                        className="w-full px-4 py-2 border border-border rounded-2xl bg-card text-foreground placeholder:text-muted-foreground focus:ring-2 focus:ring-primary focus:border-primary/50"
                                         placeholder="Enter post title"
                                     />
                                 </div>
@@ -523,7 +523,7 @@ export default function AdminBlogEditorPage() {
                                             type="text"
                                             value={post.slug}
                                             onChange={(e) => setPost({ ...post, slug: e.target.value })}
-                                            className="flex-1 px-4 py-2 border border-border rounded-2xl focus:ring-2 focus:ring-primary focus:border-primary/50"
+                                            className="flex-1 px-4 py-2 border border-border rounded-2xl bg-card text-foreground placeholder:text-muted-foreground focus:ring-2 focus:ring-primary focus:border-primary/50"
                                             placeholder="post-url-slug"
                                         />
                                     </div>
@@ -536,7 +536,7 @@ export default function AdminBlogEditorPage() {
                                         value={post.excerpt}
                                         onChange={(e) => setPost({ ...post, excerpt: e.target.value })}
                                         rows={2}
-                                        className="w-full px-4 py-2 border border-border rounded-2xl focus:ring-2 focus:ring-primary focus:border-primary/50"
+                                        className="w-full px-4 py-2 border border-border rounded-2xl bg-card text-foreground placeholder:text-muted-foreground focus:ring-2 focus:ring-primary focus:border-primary/50"
                                         placeholder="Brief summary of the post (shown in previews)"
                                     />
                                 </div>

--- a/src/app/admin/news/blog/page.tsx
+++ b/src/app/admin/news/blog/page.tsx
@@ -139,13 +139,13 @@ export default function AdminBlogListPage() {
                                 placeholder="Search posts..."
                                 value={searchQuery}
                                 onChange={(e) => setSearchQuery(e.target.value)}
-                                className="w-full pl-10 pr-4 py-2 border border-border rounded-2xl focus:ring-2 focus:ring-primary focus:border-primary/50"
+                                className="w-full pl-10 pr-4 py-2 border border-border rounded-2xl bg-card text-foreground placeholder:text-muted-foreground focus:ring-2 focus:ring-primary focus:border-primary/50"
                             />
                         </div>
                         <select
                             value={filterStatus}
                             onChange={(e) => setFilterStatus(e.target.value as typeof filterStatus)}
-                            className="px-4 py-2 border border-border rounded-2xl focus:ring-2 focus:ring-primary focus:border-primary/50"
+                            className="px-4 py-2 border border-border rounded-2xl bg-card text-foreground focus:ring-2 focus:ring-primary focus:border-primary/50"
                         >
                             <option value="all">All Posts</option>
                             <option value="published">Published</option>

--- a/src/app/admin/news/media/[id]/page.tsx
+++ b/src/app/admin/news/media/[id]/page.tsx
@@ -215,7 +215,7 @@ export default function AdminMediaEditorPage() {
                                         type="text"
                                         value={mention.title}
                                         onChange={(e) => setMention({ ...mention, title: e.target.value })}
-                                        className="w-full px-4 py-2 border border-border rounded-2xl focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
+                                        className="w-full px-4 py-2 border border-border rounded-2xl bg-card text-foreground placeholder:text-muted-foreground focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
                                         placeholder="e.g., ScamDunk Featured in TechCrunch"
                                     />
                                 </div>
@@ -228,7 +228,7 @@ export default function AdminMediaEditorPage() {
                                             type="text"
                                             value={mention.source}
                                             onChange={(e) => setMention({ ...mention, source: e.target.value })}
-                                            className="w-full px-4 py-2 border border-border rounded-2xl focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
+                                            className="w-full px-4 py-2 border border-border rounded-2xl bg-card text-foreground placeholder:text-muted-foreground focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
                                             placeholder="e.g., TechCrunch, @user123"
                                         />
                                     </div>
@@ -239,7 +239,7 @@ export default function AdminMediaEditorPage() {
                                         <select
                                             value={mention.sourceType}
                                             onChange={(e) => setMention({ ...mention, sourceType: e.target.value })}
-                                            className="w-full px-4 py-2 border border-border rounded-2xl focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
+                                            className="w-full px-4 py-2 border border-border rounded-2xl bg-card text-foreground placeholder:text-muted-foreground focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
                                         >
                                             {SOURCE_TYPES.map((type) => (
                                                 <option key={type.value} value={type.value}>
@@ -257,7 +257,7 @@ export default function AdminMediaEditorPage() {
                                         type="url"
                                         value={mention.sourceUrl}
                                         onChange={(e) => setMention({ ...mention, sourceUrl: e.target.value })}
-                                        className="w-full px-4 py-2 border border-border rounded-2xl focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
+                                        className="w-full px-4 py-2 border border-border rounded-2xl bg-card text-foreground placeholder:text-muted-foreground focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
                                         placeholder="https://example.com/article"
                                     />
                                 </div>
@@ -269,7 +269,7 @@ export default function AdminMediaEditorPage() {
                                         value={mention.description}
                                         onChange={(e) => setMention({ ...mention, description: e.target.value })}
                                         rows={3}
-                                        className="w-full px-4 py-2 border border-border rounded-2xl focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
+                                        className="w-full px-4 py-2 border border-border rounded-2xl bg-card text-foreground placeholder:text-muted-foreground focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
                                         placeholder="Brief description of what the mention is about"
                                     />
                                 </div>
@@ -281,7 +281,7 @@ export default function AdminMediaEditorPage() {
                                         value={mention.quoteText}
                                         onChange={(e) => setMention({ ...mention, quoteText: e.target.value })}
                                         rows={2}
-                                        className="w-full px-4 py-2 border border-border rounded-2xl focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
+                                        className="w-full px-4 py-2 border border-border rounded-2xl bg-card text-foreground placeholder:text-muted-foreground focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
                                         placeholder="Featured quote from the mention (if applicable)"
                                     />
                                 </div>

--- a/src/app/admin/news/media/page.tsx
+++ b/src/app/admin/news/media/page.tsx
@@ -162,13 +162,13 @@ export default function AdminMediaListPage() {
                                 placeholder="Search mentions..."
                                 value={searchQuery}
                                 onChange={(e) => setSearchQuery(e.target.value)}
-                                className="w-full pl-10 pr-4 py-2 border border-border rounded-2xl focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
+                                className="w-full pl-10 pr-4 py-2 border border-border rounded-2xl bg-card text-foreground placeholder:text-muted-foreground focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
                             />
                         </div>
                         <select
                             value={filterType}
                             onChange={(e) => setFilterType(e.target.value)}
-                            className="px-4 py-2 border border-border rounded-2xl focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
+                            className="px-4 py-2 border border-border rounded-2xl bg-card text-foreground placeholder:text-muted-foreground focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
                         >
                             <option value="all">All Types</option>
                             <option value="NEWS_OUTLET">News Outlets</option>

--- a/src/app/admin/risk-alerts/page.tsx
+++ b/src/app/admin/risk-alerts/page.tsx
@@ -143,7 +143,7 @@ export default function RiskAlertsPage() {
             <select
               value={days}
               onChange={(e) => setDays(parseInt(e.target.value))}
-              className="px-3 py-1.5 border border-border rounded-md text-sm"
+              className="px-3 py-1.5 border border-border rounded-md text-sm bg-card text-foreground"
             >
               <option value={7}>Last 7 days</option>
               <option value={14}>Last 14 days</option>
@@ -152,7 +152,7 @@ export default function RiskAlertsPage() {
             <select
               value={typeFilter}
               onChange={(e) => setTypeFilter(e.target.value)}
-              className="px-3 py-1.5 border border-border rounded-md text-sm"
+              className="px-3 py-1.5 border border-border rounded-md text-sm bg-card text-foreground"
             >
               <option value="">All Types</option>
               <option value="NEW_HIGH_RISK">New High Risk</option>

--- a/src/app/admin/scan-messages/page.tsx
+++ b/src/app/admin/scan-messages/page.tsx
@@ -446,7 +446,7 @@ export default function ScanMessagesPage() {
                   value={newHeadline}
                   onChange={(e) => setNewHeadline(e.target.value)}
                   placeholder="e.g., Let's find the scam before it finds you."
-                  className="w-full px-3 py-2 border border-border rounded-2xl focus:ring-2 focus:ring-primary focus:border-transparent"
+                  className="w-full px-3 py-2 border border-border rounded-2xl bg-card text-foreground placeholder:text-muted-foreground focus:ring-2 focus:ring-primary focus:border-transparent"
                   maxLength={100}
                 />
                 <p className="mt-1 text-xs text-muted-foreground">{newHeadline.length}/100 characters</p>
@@ -460,7 +460,7 @@ export default function ScanMessagesPage() {
                   value={newSubtext}
                   onChange={(e) => setNewSubtext(e.target.value)}
                   placeholder="e.g., Enter a ticker to check for red flags"
-                  className="w-full px-3 py-2 border border-border rounded-2xl focus:ring-2 focus:ring-primary focus:border-transparent"
+                  className="w-full px-3 py-2 border border-border rounded-2xl bg-card text-foreground placeholder:text-muted-foreground focus:ring-2 focus:ring-primary focus:border-transparent"
                   maxLength={80}
                 />
                 <p className="mt-1 text-xs text-muted-foreground">{newSubtext.length}/80 characters</p>
@@ -534,7 +534,7 @@ export default function ScanMessagesPage() {
                         value={msg.reason || ""}
                         onChange={(e) => handleSetRejectionReason(index, e.target.value)}
                         placeholder="Why was this rejected? (optional, helps improve future generations)"
-                        className="w-full px-3 py-2 text-sm border border-border rounded-2xl focus:ring-2 focus:ring-red-500 focus:border-transparent"
+                        className="w-full px-3 py-2 text-sm border border-border rounded-2xl bg-card text-foreground placeholder:text-muted-foreground focus:ring-2 focus:ring-red-500 focus:border-transparent"
                       />
                     </div>
                   )}
@@ -614,13 +614,13 @@ export default function ScanMessagesPage() {
                         type="text"
                         value={editHeadline}
                         onChange={(e) => setEditHeadline(e.target.value)}
-                        className="w-full px-3 py-2 border border-border rounded-2xl focus:ring-2 focus:ring-primary focus:border-transparent"
+                        className="w-full px-3 py-2 border border-border rounded-2xl bg-card text-foreground placeholder:text-muted-foreground focus:ring-2 focus:ring-primary focus:border-transparent"
                       />
                       <input
                         type="text"
                         value={editSubtext}
                         onChange={(e) => setEditSubtext(e.target.value)}
-                        className="w-full px-3 py-2 border border-border rounded-2xl focus:ring-2 focus:ring-primary focus:border-transparent"
+                        className="w-full px-3 py-2 border border-border rounded-2xl bg-card text-foreground placeholder:text-muted-foreground focus:ring-2 focus:ring-primary focus:border-transparent"
                       />
                       <div className="flex gap-2">
                         <button

--- a/src/app/admin/settings/page.tsx
+++ b/src/app/admin/settings/page.tsx
@@ -207,7 +207,7 @@ export default function SettingsPage() {
                     required
                     value={newEmail}
                     onChange={(e) => setNewEmail(e.target.value)}
-                    className="block w-full px-3 py-2 border border-border rounded-md shadow-sm focus:outline-none focus:ring-primary focus:border-primary sm:text-sm"
+                    className="block w-full px-3 py-2 border border-border rounded-md shadow-sm bg-card text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-primary focus:border-primary sm:text-sm"
                     placeholder="newemail@example.com"
                   />
                 </div>
@@ -227,7 +227,7 @@ export default function SettingsPage() {
                     required
                     value={emailPassword}
                     onChange={(e) => setEmailPassword(e.target.value)}
-                    className="block w-full px-3 py-2 border border-border rounded-md shadow-sm focus:outline-none focus:ring-primary focus:border-primary sm:text-sm pr-10"
+                    className="block w-full px-3 py-2 border border-border rounded-md shadow-sm bg-card text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-primary focus:border-primary sm:text-sm pr-10"
                     placeholder="Enter your current password"
                   />
                   <button
@@ -307,7 +307,7 @@ export default function SettingsPage() {
                   required
                   value={currentPassword}
                   onChange={(e) => setCurrentPassword(e.target.value)}
-                  className="block w-full px-3 py-2 border border-border rounded-md shadow-sm focus:outline-none focus:ring-primary focus:border-primary sm:text-sm pr-10"
+                  className="block w-full px-3 py-2 border border-border rounded-md shadow-sm bg-card text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-primary focus:border-primary sm:text-sm pr-10"
                   placeholder="Enter current password"
                 />
                 <button
@@ -340,7 +340,7 @@ export default function SettingsPage() {
                   minLength={8}
                   value={newPassword}
                   onChange={(e) => setNewPassword(e.target.value)}
-                  className="block w-full px-3 py-2 border border-border rounded-md shadow-sm focus:outline-none focus:ring-primary focus:border-primary sm:text-sm pr-10"
+                  className="block w-full px-3 py-2 border border-border rounded-md shadow-sm bg-card text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-primary focus:border-primary sm:text-sm pr-10"
                   placeholder="Minimum 8 characters"
                 />
                 <button
@@ -373,7 +373,7 @@ export default function SettingsPage() {
                   minLength={8}
                   value={confirmPassword}
                   onChange={(e) => setConfirmPassword(e.target.value)}
-                  className="block w-full px-3 py-2 border border-border rounded-md shadow-sm focus:outline-none focus:ring-primary focus:border-primary sm:text-sm pr-10"
+                  className="block w-full px-3 py-2 border border-border rounded-md shadow-sm bg-card text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-primary focus:border-primary sm:text-sm pr-10"
                   placeholder="Re-enter new password"
                 />
                 <button

--- a/src/app/admin/stock-lookup/page.tsx
+++ b/src/app/admin/stock-lookup/page.tsx
@@ -169,7 +169,7 @@ export default function StockLookupPage() {
                   }
                 }}
                 placeholder="Search by symbol or company name..."
-                className="w-full pl-10 pr-4 py-2 border border-border rounded-md focus:ring-primary focus:border-primary/50"
+                className="w-full pl-10 pr-4 py-2 border border-border rounded-md bg-card text-foreground placeholder:text-muted-foreground focus:ring-primary focus:border-primary/50"
               />
               {/* Search Results Dropdown */}
               {searchResults.length > 0 && (
@@ -193,7 +193,7 @@ export default function StockLookupPage() {
             <select
               value={days}
               onChange={(e) => setDays(parseInt(e.target.value))}
-              className="px-4 py-2 border border-border rounded-md"
+              className="px-4 py-2 border border-border rounded-md bg-card text-foreground"
             >
               <option value={30}>30 days</option>
               <option value={90}>90 days</option>

--- a/src/app/admin/support/page.tsx
+++ b/src/app/admin/support/page.tsx
@@ -485,14 +485,14 @@ export default function SupportPage() {
               placeholder="Search by email, name, subject, or ticket ID..."
               value={search}
               onChange={(e) => setSearch(e.target.value)}
-              className="w-full pl-10 pr-4 py-2 border border-border rounded-md focus:ring-primary focus:border-primary/50"
+              className="w-full pl-10 pr-4 py-2 border border-border rounded-md bg-card text-foreground placeholder:text-muted-foreground focus:ring-primary focus:border-primary/50"
             />
           </div>
           <div className="flex gap-2">
             <select
               value={statusFilter}
               onChange={(e) => setStatusFilter(e.target.value)}
-              className="border border-border rounded-md px-3 py-2 text-sm"
+              className="border border-border rounded-md px-3 py-2 text-sm bg-card text-foreground"
             >
               <option value="">All Status</option>
               <option value="NEW">New</option>
@@ -505,7 +505,7 @@ export default function SupportPage() {
             <select
               value={categoryFilter}
               onChange={(e) => setCategoryFilter(e.target.value)}
-              className="border border-border rounded-md px-3 py-2 text-sm"
+              className="border border-border rounded-md px-3 py-2 text-sm bg-card text-foreground"
             >
               <option value="">All Categories</option>
               <option value="SUPPORT">Technical Support</option>
@@ -518,7 +518,7 @@ export default function SupportPage() {
             <select
               value={priorityFilter}
               onChange={(e) => setPriorityFilter(e.target.value)}
-              className="border border-border rounded-md px-3 py-2 text-sm"
+              className="border border-border rounded-md px-3 py-2 text-sm bg-card text-foreground"
             >
               <option value="">All Priorities</option>
               <option value="LOW">Low</option>
@@ -689,7 +689,7 @@ export default function SupportPage() {
                         value={responseText}
                         onChange={(e) => setResponseText(e.target.value)}
                         rows={4}
-                        className="w-full border border-border rounded-2xl p-3 focus:ring-primary focus:border-primary/50"
+                        className="w-full border border-border rounded-2xl p-3 bg-card text-foreground placeholder:text-muted-foreground focus:ring-primary focus:border-primary/50"
                         placeholder="Type your response..."
                       />
                       <div className="flex items-center justify-between mt-3">

--- a/src/app/admin/team/page.tsx
+++ b/src/app/admin/team/page.tsx
@@ -346,7 +346,7 @@ export default function TeamPage() {
                       type="text"
                       value={inviteUrl}
                       readOnly
-                      className="flex-1 border border-border rounded-md px-3 py-2 text-sm bg-secondary/50"
+                      className="flex-1 border border-border rounded-md px-3 py-2 text-sm bg-card text-foreground"
                     />
                     <button
                       onClick={() => copyToClipboard(inviteUrl)}
@@ -368,7 +368,7 @@ export default function TeamPage() {
                       type="email"
                       value={inviteEmail}
                       onChange={(e) => setInviteEmail(e.target.value)}
-                      className="mt-1 block w-full border border-border rounded-md px-3 py-2"
+                      className="mt-1 block w-full border border-border rounded-md px-3 py-2 bg-card text-foreground placeholder:text-muted-foreground"
                       placeholder="user@example.com"
                     />
                   </div>
@@ -377,7 +377,7 @@ export default function TeamPage() {
                     <select
                       value={inviteRole}
                       onChange={(e) => setInviteRole(e.target.value)}
-                      className="mt-1 block w-full border border-border rounded-md px-3 py-2"
+                      className="mt-1 block w-full border border-border rounded-md px-3 py-2 bg-card text-foreground placeholder:text-muted-foreground"
                     >
                       <option value="ADMIN">Admin - Full dashboard access</option>
                       <option value="VIEWER">Viewer - Read-only access</option>

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -361,13 +361,13 @@ export default function UsersPage() {
               placeholder="Search by email or name..."
               value={search}
               onChange={(e) => setSearch(e.target.value)}
-              className="w-full pl-10 pr-4 py-2 border border-border rounded-md focus:ring-primary focus:border-primary/50"
+              className="w-full pl-10 pr-4 py-2 border border-border rounded-md bg-card text-foreground placeholder:text-muted-foreground focus:ring-primary focus:border-primary/50"
             />
           </div>
           <select
             value={planFilter}
             onChange={(e) => setPlanFilter(e.target.value)}
-            className="border border-border rounded-md px-3 py-2"
+            className="border border-border rounded-md px-3 py-2 bg-card text-foreground"
           >
             <option value="">All Plans</option>
             <option value="FREE">Free</option>
@@ -586,7 +586,7 @@ export default function UsersPage() {
                     min="0"
                     value={editValue}
                     onChange={(e) => setEditValue(parseInt(e.target.value) || 0)}
-                    className="mt-1 block w-full border border-border rounded-md px-3 py-2"
+                    className="mt-1 block w-full border border-border rounded-md px-3 py-2 bg-card text-foreground"
                   />
                   <p className="mt-1 text-sm text-muted-foreground">
                     Current value: {editModal.currentValue}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -178,16 +178,18 @@
    ANIMATIONS — Spring easing for natural motion
    ============================================ */
 
-/* Admin layout: ensure form elements use theme-aware colors */
-.admin-layout input:not([type="submit"]):not([type="button"]):not([type="reset"]):not([type="file"]),
+/* Admin layout: ensure form elements have visible text on white/card backgrounds */
+.admin-layout input:not([type="submit"]):not([type="button"]):not([type="reset"]):not([type="file"]):not([type="checkbox"]):not([type="radio"]),
 .admin-layout textarea,
 .admin-layout select {
-  color: hsl(var(--foreground));
+  color: hsl(var(--foreground)) !important;
+  background-color: hsl(var(--card)) !important;
+  border-color: hsl(var(--border));
 }
 
 .admin-layout input::placeholder,
 .admin-layout textarea::placeholder {
-  color: hsl(var(--muted-foreground));
+  color: hsl(var(--muted-foreground)) !important;
 }
 
 /* Apple-style animations */


### PR DESCRIPTION
…foreground)

Every input, textarea, and select across all 18 admin pages was missing explicit background and text color classes, causing white-on-white invisible text. Fixed by:

- globals.css: strengthened admin-layout rule with !important + bg-color
- login: replaced hardcoded text-white with text-foreground
- All 18 admin pages: added bg-card text-foreground to every form element

Pages fixed: login, users, settings, email-management, team, blog, blog editor, media, media editor, support, scan-messages, homepage, stock-lookup, api-usage, integrations, market-analysis, model-efficacy, risk-alerts

https://claude.ai/code/session_01T6G3mGFooJ75KgKqK8wzpC