### PR TITLE
fix: prevent Vercel function timeout when calling Python AI backend

### DIFF
--- a/src/app/api/ai-analyze/route.ts
+++ b/src/app/api/ai-analyze/route.ts
@@ -19,6 +19,9 @@ import { computeRiskScore } from "@/lib/scoring";
 import { canUserScan } from "@/lib/usage";
 import { sendAPIFailureAlert } from "@/lib/email";
 
+// Allow up to 30 seconds for the full AI pipeline
+export const maxDuration = 30;
+
 // Custom error for service unavailable
 class ServiceUnavailableError extends Error {
   apiName: string;
@@ -86,7 +89,7 @@ async function callAIBackend(
 ): Promise<AIBackendResponse | null> {
   try {
     const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 30000); // 30s timeout
+    const timeoutId = setTimeout(() => controller.abort(), 10000); // 10s timeout - keep short so fallback has time
 
     const response = await fetch(`${AI_BACKEND_URL}/analyze`, {
       method: "POST",

--- a/src/app/api/check/route.ts
+++ b/src/app/api/check/route.ts
@@ -17,6 +17,9 @@ import {
   RiskSignal,
 } from "@/lib/types";
 
+// Allow up to 30 seconds for the full AI pipeline (Python backend + market data + narrative)
+export const maxDuration = 30;
+
 // Custom error for service unavailable
 class ServiceUnavailableError extends Error {
   apiName: string;
@@ -84,7 +87,7 @@ async function callPythonAIBackend(
 
   try {
     const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 30000); // 30s timeout
+    const timeoutId = setTimeout(() => controller.abort(), 10000); // 10s timeout - keep short so TypeScript fallback has time
 
     console.log(`Calling Python AI backend: ${AI_BACKEND_URL}/analyze`);
 


### PR DESCRIPTION
- Add maxDuration = 30 to /api/check and /api/ai-analyze routes so Vercel allows enough time for the full 4-layer AI pipeline
- Reduce Python backend call timeout from 30s to 10s so the TypeScript fallback scoring has time to run if the AI backend is slow

Without maxDuration, Vercel's default 10s timeout kills the function before the Python backend can respond, causing "fetch failed" errors.

https://claude.ai/code/session_015wnMpGKWSMA3nGtH3Hu8nT