### PR TITLE
Wire up ScanResultsLayout in HomeContent to complete the scan results…

### DIFF
--- a/src/app/HomeContent.tsx
+++ b/src/app/HomeContent.tsx
@@ -2,15 +2,14 @@
 
 import { useState, useEffect } from "react";
 import { useSession } from "next-auth/react";
-import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Sidebar } from "@/components/Sidebar";
 import { Header } from "@/components/Header";
 import { ScanInput } from "@/components/ScanInput";
-import { RiskCard } from "@/components/RiskCard";
 import { LimitReached } from "@/components/LimitReached";
 import { LoadingStepper } from "@/components/LoadingStepper";
-import { Shield, TrendingUp, AlertTriangle, Zap, Sparkles, ArrowRight, BarChart3, Eye, Brain } from "lucide-react";
+import { ScanResultsLayout } from "@/components/ScanResultsLayout";
+import { Shield, AlertTriangle, Eye } from "lucide-react";
 import { RiskResponse, LimitReachedResponse, UsageInfo, AssetType } from "@/lib/types";
 import { getRandomTagline, taglines } from "@/lib/taglines";
 import { LandingOptionA } from "@/components/landing/LandingOptionA";
@@ -37,6 +36,7 @@ export default function HomeContent() {
   const [limitReached, setLimitReached] = useState<LimitReachedResponse | null>(null);
   const [usage, setUsage] = useState<UsageInfo | null>(null);
   const [currentTicker, setCurrentTicker] = useState("");
+  const [hasChatData, setHasChatData] = useState(false);
 
   const [steps, setSteps] = useState<Step[]>([
     { label: "Validating ticker symbol", status: "pending" },
@@ -118,6 +118,7 @@ export default function HomeContent() {
     setLimitReached(null);
     setIsLoading(true);
     setCurrentTicker(data.ticker);
+    setHasChatData(!!data.pitchText?.trim());
 
     // Reset steps with enhanced granular progress
     const initialSteps: Step[] = [
@@ -411,19 +412,9 @@ export default function HomeContent() {
             </div>
           )}
 
-          {/* Results */}
+          {/* Results — new split-screen layout */}
           {result && !isLoading && (
-            <div className="flex-1 overflow-y-auto p-4 pb-8">
-              <div className="max-w-3xl mx-auto space-y-6 animate-slide-up">
-                <RiskCard result={result} />
-                <div className="flex justify-center gap-3">
-                  <Button variant="outline" onClick={handleNewScan} className="gap-2">
-                    <Sparkles className="h-4 w-4" />
-                    Check another
-                  </Button>
-                </div>
-              </div>
-            </div>
+            <ScanResultsLayout result={result} hasChatData={hasChatData} onNewScan={handleNewScan} />
           )}
 
           {/* Welcome State (no result, not loading) */}

--- a/src/components/ScanResultsLayout.tsx
+++ b/src/components/ScanResultsLayout.tsx
@@ -10,12 +10,15 @@ import {
   ClipboardList,
   FileText,
   AlertTriangle,
+  Sparkles,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
 
 interface ScanResultsLayoutProps {
   result: RiskResponse;
   hasChatData: boolean;
+  onNewScan?: () => void;
 }
 
 /* ─── Right-side info panel content ─── */
@@ -121,7 +124,7 @@ function InfoPanel({
 
 /* ─── Main Layout ─── */
 
-export function ScanResultsLayout({ result, hasChatData }: ScanResultsLayoutProps) {
+export function ScanResultsLayout({ result, hasChatData, onNewScan }: ScanResultsLayoutProps) {
   return (
     <div className="flex-1 flex flex-col min-h-0">
       {/* Main content area — fills remaining viewport height */}
@@ -130,6 +133,14 @@ export function ScanResultsLayout({ result, hasChatData }: ScanResultsLayoutProp
         <div className="lg:w-3/5 flex flex-col min-h-0">
           <div className="flex-1 overflow-y-auto min-h-0 scrollbar-thin">
             <RiskCard result={result} hasChatData={hasChatData} />
+            {onNewScan && (
+              <div className="flex justify-center py-4">
+                <Button variant="outline" onClick={onNewScan} className="gap-2">
+                  <Sparkles className="h-4 w-4" />
+                  Check another
+                </Button>
+              </div>
+            )}
           </div>
         </div>
 


### PR DESCRIPTION
… redesign

The redesigned split-screen layout (ScanResultsLayout) was created but never connected in HomeContent.tsx. The old simple centered layout was still being used, causing users to see a mix of old and new design elements.

Changes:
- Replace old inline results layout with ScanResultsLayout component
- Pass hasChatData prop based on whether user provided pitch text
- Add onNewScan callback and "Check another" button to ScanResultsLayout
- Clean up unused imports in HomeContent.tsx

https://claude.ai/code/session_01JuTss24fFUXJHGkGjNWKHM