### PR TITLE
Clarify Discord bot vs personal accounts on integrations dashboard

### DIFF
--- a/src/app/admin/integrations/page.tsx
+++ b/src/app/admin/integrations/page.tsx
@@ -11,6 +11,9 @@ import {
   ExternalLink,
   Settings,
   Loader2,
+  Bot,
+  User,
+  AlertTriangle,
 } from "lucide-react";
 
 interface Integration {
@@ -213,9 +216,18 @@ export default function IntegrationsPage() {
         ) : (
           Object.entries(groupedIntegrations).map(([category, items]) => (
             <div key={category} className="space-y-4">
-              <h2 className="text-lg font-medium text-foreground capitalize">
-                {category.toLowerCase()} Integrations
+              <h2 className="text-lg font-medium text-foreground">
+                {category === "BROWSER_AGENT"
+                  ? "Personal Account Credentials (Browser Agents)"
+                  : category === "SOCIAL_SCAN"
+                    ? "Social Media Scan APIs"
+                    : `${category.charAt(0) + category.slice(1).toLowerCase()} Integrations`}
               </h2>
+              {category === "BROWSER_AGENT" && (
+                <p className="text-sm text-muted-foreground -mt-2">
+                  Your personal social media accounts used by browser agents to scan platforms that don&apos;t have public APIs.
+                </p>
+              )}
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 {items.map((integration) => (
                   <div
@@ -228,9 +240,23 @@ export default function IntegrationsPage() {
                       <div className="flex items-center">
                         {getStatusIcon(integration.status)}
                         <div className="ml-3">
-                          <h3 className="text-lg font-medium text-foreground">
-                            {integration.displayName}
-                          </h3>
+                          <div className="flex items-center gap-2">
+                            <h3 className="text-lg font-medium text-foreground">
+                              {integration.displayName}
+                            </h3>
+                            {integration.name === "DISCORD_BOT" && (
+                              <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-purple-100 text-purple-800">
+                                <Bot className="h-3 w-3" />
+                                Bot
+                              </span>
+                            )}
+                            {integration.category === "BROWSER_AGENT" && integration.name !== "BROWSER_ENCRYPTION_KEY" && (
+                              <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
+                                <User className="h-3 w-3" />
+                                Personal
+                              </span>
+                            )}
+                          </div>
                           <p className="text-sm text-muted-foreground">{integration.description}</p>
                         </div>
                       </div>
@@ -242,10 +268,23 @@ export default function IntegrationsPage() {
                         {integration.status}
                       </span>
                     </div>
+                    {/* Special notes for specific integrations */}
+                    {integration.name === "DISCORD_BOT" && integration.apiKeyMasked !== "Not configured" && (
+                      <div className="mt-2 p-2 bg-amber-50 border border-amber-200 rounded text-sm text-amber-800 flex items-start gap-2">
+                        <AlertTriangle className="h-4 w-4 mt-0.5 flex-shrink-0" />
+                        <span>Bot is set up but not linked to any Discord servers yet. Invite the bot to target servers to start monitoring.</span>
+                      </div>
+                    )}
 
                     <div className="mt-4 space-y-2">
                       <div className="flex justify-between text-sm">
-                        <span className="text-muted-foreground">API Key</span>
+                        <span className="text-muted-foreground">
+                          {integration.category === "BROWSER_AGENT" && integration.name !== "BROWSER_ENCRYPTION_KEY"
+                            ? "Account"
+                            : integration.name === "DISCORD_BOT"
+                              ? "Bot Token"
+                              : "API Key"}
+                        </span>
                         <span className="font-mono text-foreground">
                           {integration.apiKeyMasked || "Not configured"}
                         </span>

--- a/src/lib/admin/integrations.ts
+++ b/src/lib/admin/integrations.ts
@@ -9,8 +9,10 @@ import { config } from "@/lib/config";
 /**
  * Mask an API key for display (show first 4 and last 4 characters)
  */
-function maskApiKey(key: string | undefined): string {
-  if (!key || key.length < 12) return "Not configured";
+function maskApiKey(key: string | undefined, showFull = false): string {
+  if (!key || key.length === 0) return "Not configured";
+  if (showFull) return key;
+  if (key.length < 12) return "Not configured";
   return `${key.substring(0, 4)}...${key.substring(key.length - 4)}`;
 }
 
@@ -368,9 +370,9 @@ const INTEGRATIONS = [
   },
   {
     name: "REDDIT_OAUTH",
-    displayName: "Reddit OAuth",
+    displayName: "Reddit OAuth API",
     category: "SOCIAL_SCAN",
-    description: "Authenticated Reddit search for stock mentions (60 req/min)",
+    description: "Reddit API app credentials for authenticated search (separate from personal account)",
     getApiKey: () => config.redditClientId,
     testConnection: testRedditOAuth,
     rateLimit: 60,
@@ -410,7 +412,7 @@ const INTEGRATIONS = [
     name: "DISCORD_BOT",
     displayName: "Discord Bot",
     category: "SOCIAL_SCAN",
-    description: "Monitors Discord servers for stock promotion activity",
+    description: "Bot created but not yet linked to any servers. Needs server invites to begin monitoring.",
     getApiKey: () => config.discordBotToken,
     testConnection: testDiscordBot,
     documentation: "https://discord.com/developers/docs",
@@ -424,53 +426,59 @@ const INTEGRATIONS = [
     testConnection: testCrowdTangle,
     documentation: "https://www.crowdtangle.com/",
   },
-  // Browser Agent Platform Credentials
+  // Browser Agent Platform Credentials (personal accounts)
   {
     name: "BROWSER_DISCORD",
-    displayName: "Discord (Browser Agent)",
+    displayName: "Discord (Personal Account)",
     category: "BROWSER_AGENT",
-    description: "Personal Discord account for browser-based server scanning",
+    description: "Owner's personal Discord account for browser-based server scanning",
     getApiKey: () => config.browserDiscordEmail,
+    showFullKey: true,
     testConnection: testBrowserCredential("browserDiscordEmail", "browserDiscordPassword"),
   },
   {
     name: "BROWSER_REDDIT",
-    displayName: "Reddit (Browser Agent)",
+    displayName: "Reddit (Personal Account)",
     category: "BROWSER_AGENT",
-    description: "Personal Reddit account for browser-based subreddit scanning",
+    description: "Owner's personal Reddit account for browser-based subreddit scanning",
     getApiKey: () => config.browserRedditUsername,
+    showFullKey: true,
     testConnection: testBrowserCredential("browserRedditUsername", "browserRedditPassword"),
   },
   {
     name: "BROWSER_TWITTER",
-    displayName: "Twitter/X (Browser Agent)",
+    displayName: "Twitter/X (Personal Account)",
     category: "BROWSER_AGENT",
-    description: "Personal Twitter/X account for browser-based cashtag scanning",
+    description: "Owner's personal Twitter/X account for browser-based cashtag scanning",
     getApiKey: () => config.browserTwitterUsername,
+    showFullKey: true,
     testConnection: testBrowserCredential("browserTwitterUsername", "browserTwitterPassword"),
   },
   {
     name: "BROWSER_INSTAGRAM",
-    displayName: "Instagram (Browser Agent)",
+    displayName: "Instagram (Personal Account)",
     category: "BROWSER_AGENT",
-    description: "Personal Instagram account for browser-based hashtag scanning",
+    description: "Owner's personal Instagram account for browser-based hashtag scanning",
     getApiKey: () => config.browserInstagramUsername,
+    showFullKey: true,
     testConnection: testBrowserCredential("browserInstagramUsername", "browserInstagramPassword"),
   },
   {
     name: "BROWSER_FACEBOOK",
-    displayName: "Facebook (Browser Agent)",
+    displayName: "Facebook (Personal Account)",
     category: "BROWSER_AGENT",
-    description: "Personal Facebook account for browser-based group scanning",
+    description: "Owner's personal Facebook account for browser-based group scanning",
     getApiKey: () => config.browserFacebookEmail,
+    showFullKey: true,
     testConnection: testBrowserCredential("browserFacebookEmail", "browserFacebookPassword"),
   },
   {
     name: "BROWSER_TIKTOK",
-    displayName: "TikTok (Browser Agent)",
+    displayName: "TikTok (Personal Account)",
     category: "BROWSER_AGENT",
-    description: "Personal TikTok account for browser-based hashtag scanning",
+    description: "Owner's personal TikTok account for browser-based hashtag scanning",
     getApiKey: () => config.browserTiktokUsername,
+    showFullKey: true,
     testConnection: testBrowserCredential("browserTiktokUsername", "browserTiktokPassword"),
   },
   {
@@ -492,6 +500,8 @@ export async function initializeIntegrations() {
       where: { name: integration.name },
     });
 
+    const showFull = 'showFullKey' in integration && integration.showFullKey === true;
+
     if (!existing) {
       await prisma.integrationConfig.create({
         data: {
@@ -499,18 +509,21 @@ export async function initializeIntegrations() {
           displayName: integration.displayName,
           category: integration.category,
           isEnabled: true,
-          apiKeyMasked: maskApiKey(integration.getApiKey()),
+          apiKeyMasked: maskApiKey(integration.getApiKey(), showFull),
           rateLimit: integration.rateLimit,
           status: "UNKNOWN",
         },
       });
     } else {
-      // Update masked API key if changed
-      const newMasked = maskApiKey(integration.getApiKey());
-      if (existing.apiKeyMasked !== newMasked) {
+      // Update masked API key (or full username) if changed
+      const newMasked = maskApiKey(integration.getApiKey(), showFull);
+      if (existing.apiKeyMasked !== newMasked || existing.displayName !== integration.displayName) {
         await prisma.integrationConfig.update({
           where: { name: integration.name },
-          data: { apiKeyMasked: newMasked },
+          data: {
+            apiKeyMasked: newMasked,
+            displayName: integration.displayName,
+          },
         });
       }
     }


### PR DESCRIPTION
- Discord Bot: add warning that bot is set up but not linked to any servers
- Rename browser agent entries from "(Browser Agent)" to "(Personal Account)"
- Add Bot/Personal badges to integration cards
- Show category headers: "Personal Account Credentials" and "Social Media Scan APIs"
- Show full usernames (not masked) for personal account credentials
- Label fields as "Account" / "Bot Token" / "API Key" contextually

https://claude.ai/code/session_01FqBJ59iskYPDipfCxtZujX