### PR TITLE
Close sidebar when scan results appear, nudge learn more left

### DIFF
--- a/src/app/HomeContent.tsx
+++ b/src/app/HomeContent.tsx
@@ -297,6 +297,7 @@ export default function HomeContent() {
       } else {
         setResult(responseData as RiskResponse);
         setUsage(responseData.usage);
+        setSidebarOpen(false);
       }
     } catch (err) {
       clearInterval(tipInterval);

--- a/src/components/ScanResultsLayout.tsx
+++ b/src/components/ScanResultsLayout.tsx
@@ -145,7 +145,7 @@ export function ScanResultsLayout({ result, hasChatData, onNewScan }: ScanResult
         </div>
 
         {/* Right side — rightmost quarter, near top */}
-        <div className="lg:w-1/4 lg:max-w-[320px] flex flex-col justify-start pt-4 min-h-0 lg:ml-auto">
+        <div className="lg:w-1/4 lg:max-w-[320px] flex flex-col justify-start pt-4 min-h-0">
           <div className="flex flex-col gap-2.5 overflow-y-auto scrollbar-thin">
             <div className="flex items-center gap-2 mb-1 flex-shrink-0">
               <AlertTriangle className="h-3.5 w-3.5 text-primary/60" />


### PR DESCRIPTION
- Auto-close sidebar (setSidebarOpen(false)) after results load so it doesn't obscure the left edge of the score card
- Remove ml-auto from learn more panel to shift it slightly left

https://claude.ai/code/session_01JuTss24fFUXJHGkGjNWKHM