### PR TITLE
Remove formerPro column that was never migrated to database

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,7 +19,6 @@ model User {
   emailVerified     DateTime?
   image             String?
   plan              String    @default("FREE") // FREE or PAID
-  formerPro         Boolean   @default(false)  // true if user ever cancelled a Pro subscription
   billingCustomerId String?
   createdAt         DateTime  @default(now())
   updatedAt         DateTime  @updatedAt

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -29,7 +29,6 @@ interface User {
   email: string;
   name: string | null;
   plan: string;
-  formerPro: boolean;
   billingCustomerId: string | null;
   createdAt: string;
   scansThisMonth: number;
@@ -42,7 +41,6 @@ interface UserDetails {
     email: string;
     name: string | null;
     plan: string;
-    formerPro: boolean;
     billingCustomerId: string | null;
     emailVerified: string | null;
     createdAt: string;
@@ -73,7 +71,6 @@ interface Stats {
   totalUsers: number;
   freeUsers: number;
   paidUsers: number;
-  formerProUsers: number;
   newUsersLast30Days: number;
 }
 
@@ -171,23 +168,16 @@ export default function UsersPage() {
     }
   }
 
-  function getPlanBadge(plan: string, formerPro?: boolean) {
+  function getPlanBadge(plan: string) {
     return plan === "PAID" ? (
       <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">
         <CreditCard className="h-3 w-3 mr-1" />
         PAID
       </span>
     ) : (
-      <div className="flex items-center gap-1.5">
-        <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-secondary text-foreground">
-          FREE
-        </span>
-        {formerPro && (
-          <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-800">
-            Former PRO
-          </span>
-        )}
-      </div>
+      <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-secondary text-foreground">
+        FREE
+      </span>
     );
   }
 
@@ -219,7 +209,7 @@ export default function UsersPage() {
     {
       key: "plan",
       header: "Plan",
-      render: (item: User) => getPlanBadge(item.plan, item.formerPro),
+      render: (item: User) => getPlanBadge(item.plan),
     },
     {
       key: "scansThisMonth",
@@ -354,11 +344,10 @@ export default function UsersPage() {
 
         {/* Stats */}
         {stats && (
-          <div className="grid grid-cols-2 md:grid-cols-5 gap-6">
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-6">
             <StatCard title="Total Users" value={stats.totalUsers} icon={Users} color="blue" />
             <StatCard title="Free Users" value={stats.freeUsers} icon={Users} color="gray" />
             <StatCard title="Paid Users" value={stats.paidUsers} icon={CreditCard} color="green" />
-            <StatCard title="Former PRO" value={stats.formerProUsers} icon={CreditCard} color="yellow" />
             <StatCard title="New (30 days)" value={stats.newUsersLast30Days} icon={UserPlus} color="indigo" />
           </div>
         )}
@@ -427,7 +416,7 @@ export default function UsersPage() {
                     </div>
                     <div>
                       <p className="text-sm text-muted-foreground">Plan</p>
-                      <p>{getPlanBadge(selectedUser.user.plan, selectedUser.user.formerPro)}</p>
+                      <p>{getPlanBadge(selectedUser.user.plan)}</p>
                     </div>
                     <div>
                       <p className="text-sm text-muted-foreground">Joined</p>

--- a/src/app/api/admin/users/[id]/route.ts
+++ b/src/app/api/admin/users/[id]/route.ts
@@ -73,7 +73,6 @@ export async function GET(
         email: user.email,
         name: user.name,
         plan: user.plan,
-        formerPro: user.formerPro,
         billingCustomerId: user.billingCustomerId,
         emailVerified: user.emailVerified,
         createdAt: user.createdAt,

--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -69,7 +69,6 @@ export async function GET(request: NextRequest) {
         email: user.email,
         name: user.name,
         plan: user.plan,
-        formerPro: user.formerPro,
         billingCustomerId: user.billingCustomerId,
         createdAt: user.createdAt,
         updatedAt: user.updatedAt,
@@ -85,9 +84,8 @@ export async function GET(request: NextRequest) {
       _count: true,
     });
 
-    const [totalUsers, formerProUsers, newUsersLast30Days] = await Promise.all([
+    const [totalUsers, newUsersLast30Days] = await Promise.all([
       prisma.user.count(),
-      prisma.user.count({ where: { formerPro: true } }),
       prisma.user.count({
         where: { createdAt: { gte: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000) } },
       }),
@@ -105,7 +103,6 @@ export async function GET(request: NextRequest) {
         totalUsers,
         freeUsers: stats.find((s) => s.plan === "FREE")?._count || 0,
         paidUsers: stats.find((s) => s.plan === "PAID")?._count || 0,
-        formerProUsers,
         newUsersLast30Days,
       },
     });
@@ -154,7 +151,7 @@ export async function PATCH(request: NextRequest) {
         break;
 
       case "downgradeToFree":
-        updateData = { plan: "FREE", formerPro: true };
+        updateData = { plan: "FREE" };
         logDetails = "Downgraded user to FREE plan";
         break;
 

--- a/src/lib/paypal.ts
+++ b/src/lib/paypal.ts
@@ -233,7 +233,7 @@ export async function handleWebhook(
         if (user) {
           await prisma.user.update({
             where: { id: user.id },
-            data: { plan: "FREE", formerPro: true },
+            data: { plan: "FREE" },
           });
           console.log(`User ${user.id} downgraded to FREE plan (PayPal subscription ${eventType})`);
         }
@@ -255,7 +255,6 @@ export async function handleWebhook(
             where: { id: user.id },
             data: {
               plan: newPlan,
-              ...(newPlan === "FREE" ? { formerPro: true } : {}),
             },
           });
           console.log(`User ${user.id} subscription updated: ${status}`);
@@ -440,10 +439,10 @@ export async function cancelSubscription(
       console.log(`User ${userId} cancelled manually-upgraded Pro plan (no PayPal subscription)`);
     }
 
-    // Update user to FREE plan and mark as former Pro
+    // Update user to FREE plan
     await prisma.user.update({
       where: { id: userId },
-      data: { plan: "FREE", formerPro: true },
+      data: { plan: "FREE" },
     });
 
     return { success: true };


### PR DESCRIPTION
The formerPro field existed in the Prisma schema but was never pushed to the actual database, causing "column does not exist" errors on subscription cancellation, webhook processing, and admin user management.

Removed from: schema.prisma, paypal.ts (cancel + webhooks), admin users API routes, and admin users page UI.

https://claude.ai/code/session_01MrARCaiki2wmP7cpg6WsmL