### PR TITLE
Restore formerPro field — run prisma db push to add column

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,6 +19,7 @@ model User {
   emailVerified     DateTime?
   image             String?
   plan              String    @default("FREE") // FREE or PAID
+  formerPro         Boolean   @default(false)  // true if user ever cancelled a Pro subscription
   billingCustomerId String?
   createdAt         DateTime  @default(now())
   updatedAt         DateTime  @updatedAt

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -29,6 +29,7 @@ interface User {
   email: string;
   name: string | null;
   plan: string;
+  formerPro: boolean;
   billingCustomerId: string | null;
   createdAt: string;
   scansThisMonth: number;
@@ -41,6 +42,7 @@ interface UserDetails {
     email: string;
     name: string | null;
     plan: string;
+    formerPro: boolean;
     billingCustomerId: string | null;
     emailVerified: string | null;
     createdAt: string;
@@ -71,6 +73,7 @@ interface Stats {
   totalUsers: number;
   freeUsers: number;
   paidUsers: number;
+  formerProUsers: number;
   newUsersLast30Days: number;
 }
 
@@ -168,16 +171,23 @@ export default function UsersPage() {
     }
   }
 
-  function getPlanBadge(plan: string) {
+  function getPlanBadge(plan: string, formerPro?: boolean) {
     return plan === "PAID" ? (
       <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">
         <CreditCard className="h-3 w-3 mr-1" />
         PAID
       </span>
     ) : (
-      <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-secondary text-foreground">
-        FREE
-      </span>
+      <div className="flex items-center gap-1.5">
+        <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-secondary text-foreground">
+          FREE
+        </span>
+        {formerPro && (
+          <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-800">
+            Former PRO
+          </span>
+        )}
+      </div>
     );
   }
 
@@ -209,7 +219,7 @@ export default function UsersPage() {
     {
       key: "plan",
       header: "Plan",
-      render: (item: User) => getPlanBadge(item.plan),
+      render: (item: User) => getPlanBadge(item.plan, item.formerPro),
     },
     {
       key: "scansThisMonth",
@@ -344,10 +354,11 @@ export default function UsersPage() {
 
         {/* Stats */}
         {stats && (
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-6">
+          <div className="grid grid-cols-2 md:grid-cols-5 gap-6">
             <StatCard title="Total Users" value={stats.totalUsers} icon={Users} color="blue" />
             <StatCard title="Free Users" value={stats.freeUsers} icon={Users} color="gray" />
             <StatCard title="Paid Users" value={stats.paidUsers} icon={CreditCard} color="green" />
+            <StatCard title="Former PRO" value={stats.formerProUsers} icon={CreditCard} color="yellow" />
             <StatCard title="New (30 days)" value={stats.newUsersLast30Days} icon={UserPlus} color="indigo" />
           </div>
         )}
@@ -416,7 +427,7 @@ export default function UsersPage() {
                     </div>
                     <div>
                       <p className="text-sm text-muted-foreground">Plan</p>
-                      <p>{getPlanBadge(selectedUser.user.plan)}</p>
+                      <p>{getPlanBadge(selectedUser.user.plan, selectedUser.user.formerPro)}</p>
                     </div>
                     <div>
                       <p className="text-sm text-muted-foreground">Joined</p>

--- a/src/app/api/admin/users/[id]/route.ts
+++ b/src/app/api/admin/users/[id]/route.ts
@@ -73,6 +73,7 @@ export async function GET(
         email: user.email,
         name: user.name,
         plan: user.plan,
+        formerPro: user.formerPro,
         billingCustomerId: user.billingCustomerId,
         emailVerified: user.emailVerified,
         createdAt: user.createdAt,

--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -69,6 +69,7 @@ export async function GET(request: NextRequest) {
         email: user.email,
         name: user.name,
         plan: user.plan,
+        formerPro: user.formerPro,
         billingCustomerId: user.billingCustomerId,
         createdAt: user.createdAt,
         updatedAt: user.updatedAt,
@@ -84,8 +85,9 @@ export async function GET(request: NextRequest) {
       _count: true,
     });
 
-    const [totalUsers, newUsersLast30Days] = await Promise.all([
+    const [totalUsers, formerProUsers, newUsersLast30Days] = await Promise.all([
       prisma.user.count(),
+      prisma.user.count({ where: { formerPro: true } }),
       prisma.user.count({
         where: { createdAt: { gte: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000) } },
       }),
@@ -103,6 +105,7 @@ export async function GET(request: NextRequest) {
         totalUsers,
         freeUsers: stats.find((s) => s.plan === "FREE")?._count || 0,
         paidUsers: stats.find((s) => s.plan === "PAID")?._count || 0,
+        formerProUsers,
         newUsersLast30Days,
       },
     });
@@ -151,7 +154,7 @@ export async function PATCH(request: NextRequest) {
         break;
 
       case "downgradeToFree":
-        updateData = { plan: "FREE" };
+        updateData = { plan: "FREE", formerPro: true };
         logDetails = "Downgraded user to FREE plan";
         break;
 

--- a/src/lib/paypal.ts
+++ b/src/lib/paypal.ts
@@ -233,7 +233,7 @@ export async function handleWebhook(
         if (user) {
           await prisma.user.update({
             where: { id: user.id },
-            data: { plan: "FREE" },
+            data: { plan: "FREE", formerPro: true },
           });
           console.log(`User ${user.id} downgraded to FREE plan (PayPal subscription ${eventType})`);
         }
@@ -255,6 +255,7 @@ export async function handleWebhook(
             where: { id: user.id },
             data: {
               plan: newPlan,
+              ...(newPlan === "FREE" ? { formerPro: true } : {}),
             },
           });
           console.log(`User ${user.id} subscription updated: ${status}`);
@@ -439,10 +440,10 @@ export async function cancelSubscription(
       console.log(`User ${userId} cancelled manually-upgraded Pro plan (no PayPal subscription)`);
     }
 
-    // Update user to FREE plan
+    // Update user to FREE plan and mark as former Pro
     await prisma.user.update({
       where: { id: userId },
-      data: { plan: "FREE" },
+      data: { plan: "FREE", formerPro: true },
     });
 
     return { success: true };


### PR DESCRIPTION
Reverts the formerPro removal. The field was always in the schema but the database migration was never run. Instead of removing the feature, the fix is to run `npx prisma db push` in the deployment environment to add the missing column to the database.

IMPORTANT: Run `npx prisma db push` after deploying this to add the formerPro column to the production database.

https://claude.ai/code/session_01MrARCaiki2wmP7cpg6WsmL