### PR TITLE
fix(security): resolve all 12 CRITICAL audit findings (C-01 through C…

### DIFF
--- a/prisma/seed/admin-seed.ts
+++ b/prisma/seed/admin-seed.ts
@@ -11,10 +11,14 @@ import bcrypt from "bcryptjs";
 
 const prisma = new PrismaClient();
 
-// Initial admin owner credentials
-const ADMIN_EMAIL = "elimizroch@gmail.com";
-const ADMIN_PASSWORD = "AdminPassword123!";
-const ADMIN_NAME = "Eli Mizroch";
+// Admin owner credentials from environment
+const ADMIN_EMAIL = process.env.ADMIN_SEED_EMAIL;
+const ADMIN_PASSWORD = process.env.ADMIN_SEED_PASSWORD;
+const ADMIN_NAME = process.env.ADMIN_SEED_NAME || "Admin Owner";
+
+if (!ADMIN_EMAIL || !ADMIN_PASSWORD) {
+  throw new Error("ADMIN_SEED_EMAIL and ADMIN_SEED_PASSWORD must be set");
+}
 
 // Default integrations to create
 const DEFAULT_INTEGRATIONS = [
@@ -113,9 +117,7 @@ async function main() {
   }
 
   console.log("\nAdmin seed completed successfully!");
-  console.log(`\nLogin credentials:`);
-  console.log(`  Email: ${ADMIN_EMAIL}`);
-  console.log(`  Password: ${ADMIN_PASSWORD}`);
+  console.log(`\nAdmin email: ${ADMIN_EMAIL}`);
   console.log(`\nAccess the admin panel at: /admin/login`);
 }
 

--- a/src/app/api/admin/init/route.ts
+++ b/src/app/api/admin/init/route.ts
@@ -11,8 +11,23 @@ export const dynamic = 'force-dynamic';
 
 export async function POST(request: NextRequest) {
   try {
+    const setupKey = process.env.ADMIN_SETUP_KEY;
+    if (!setupKey) {
+      return NextResponse.json(
+        { error: "Admin setup is disabled" },
+        { status: 403 }
+      );
+    }
+
     const body = await request.json().catch(() => ({}));
     const { email, password, name } = body;
+
+    if (body.setupKey !== setupKey) {
+      return NextResponse.json(
+        { error: "Invalid setup key" },
+        { status: 403 }
+      );
+    }
 
     // Try to create the AdminUser table by attempting a query
     // If it fails, the tables don't exist

--- a/src/app/api/admin/setup/route.ts
+++ b/src/app/api/admin/setup/route.ts
@@ -14,7 +14,7 @@ const setupSchema = z.object({
   email: z.string().email("Invalid email address"),
   password: z.string().min(8, "Password must be at least 8 characters"),
   name: z.string().optional(),
-  setupKey: z.string().optional(), // Optional secret key for additional security
+  setupKey: z.string().optional(),
 });
 
 export async function GET() {
@@ -58,9 +58,15 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Optional: Check setup key for additional security
+    // Require setup key
     const expectedSetupKey = process.env.ADMIN_SETUP_KEY;
-    if (expectedSetupKey && validation.data.setupKey !== expectedSetupKey) {
+    if (!expectedSetupKey) {
+      return NextResponse.json(
+        { error: "Admin setup is disabled" },
+        { status: 403 }
+      );
+    }
+    if (validation.data.setupKey !== expectedSetupKey) {
       return NextResponse.json(
         { error: "Invalid setup key" },
         { status: 403 }

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -7,6 +7,8 @@
 
 export async function register() {
   if (process.env.NEXT_RUNTIME === "nodejs") {
+    const { validateRequiredEnvVars } = await import("@/lib/config");
+    validateRequiredEnvVars();
     await import("../sentry.server.config");
   }
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -69,6 +69,20 @@ export const config = {
   browserSessionEncryptionKey: process.env.BROWSER_SESSION_ENCRYPTION_KEY || "",
 } as const;
 
+/**
+ * Validate required environment variables at startup.
+ * Throws if critical secrets are missing.
+ */
+export function validateRequiredEnvVars(): void {
+  const required = ["NEXTAUTH_SECRET", "DATABASE_URL"];
+  const missing = required.filter((key) => !process.env[key]);
+  if (missing.length > 0) {
+    throw new Error(
+      `FATAL: Missing required environment variables: ${missing.join(", ")}`
+    );
+  }
+}
+
 // Get scan limit based on plan
 export function getScanLimit(plan: "FREE" | "PAID"): number {
   return plan === "PAID" ? config.paidChecksPerMonth : config.freeChecksPerMonth;

--- a/src/lib/mobile-auth.ts
+++ b/src/lib/mobile-auth.ts
@@ -10,7 +10,10 @@ import { prisma } from "./db";
 import { Plan } from "./types";
 
 // JWT Configuration
-const JWT_SECRET = process.env.JWT_SECRET || process.env.NEXTAUTH_SECRET || "fallback-secret-change-me";
+const JWT_SECRET = process.env.JWT_SECRET || process.env.NEXTAUTH_SECRET;
+if (!JWT_SECRET) {
+  throw new Error("FATAL: JWT_SECRET or NEXTAUTH_SECRET must be set");
+}
 const JWT_EXPIRY = "7d";
 const JWT_REFRESH_EXPIRY = "30d";
 

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -18,6 +18,13 @@ const isRedisConfigured = Boolean(
   process.env.UPSTASH_REDIS_REST_URL && process.env.UPSTASH_REDIS_REST_TOKEN
 );
 
+const isProduction = process.env.NODE_ENV === "production";
+if (isProduction && !isRedisConfigured) {
+  throw new Error(
+    "FATAL: Redis (UPSTASH_REDIS_REST_URL, UPSTASH_REDIS_REST_TOKEN) must be configured in production for rate limiting"
+  );
+}
+
 // Initialize Redis client if configured
 const redis = isRedisConfigured
   ? new Redis({


### PR DESCRIPTION
…-12)

- C-01: Remove hardcoded JWT fallback secret, throw if missing
- C-02: Validate Bearer token JWT in middleware using jose
- C-03: Require ADMIN_SETUP_KEY for admin init/setup endpoints
- C-04: Use env vars for admin seed credentials, remove password logging
- C-05: Remove auto email verification on mobile registration
- C-06: Make password reset token consumption atomic via $transaction
- C-07: Make PayPal webhook signature verification required
- C-08: Add subscription ownership verification to PayPal activate
- C-09: Add required env var validation at startup (instrumentation.ts)
- C-10: Add API key authentication to Python AI endpoints
- C-11: Restrict Python CORS to specific origin, disable credentials
- C-12: Require Redis for rate limiting in production

https://claude.ai/code/session_01W7p9QHR76rTcdDGYAqpE2B