### PR TITLE
fix(security): resolve MEDIUM auth/session issues M-01 through M-09

### DIFF
--- a/src/app/api/auth/resend-verification/route.ts
+++ b/src/app/api/auth/resend-verification/route.ts
@@ -34,10 +34,8 @@ export async function POST(request: NextRequest) {
     }
 
     if (user.emailVerified) {
-      return NextResponse.json(
-        { error: "Email is already verified" },
-        { status: 400 }
-      );
+      // Return generic response to prevent user enumeration
+      return NextResponse.json({ success: true });
     }
 
     // Create new verification token and send email

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,6 +1,27 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
 
+// Resets on cold start, so cleanup may run more often than every 24h on serverless.
+// This is acceptable — the queries are idempotent DELETEs of already-expired rows.
+let lastCleanupRun = 0;
+const CLEANUP_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+async function cleanupExpiredTokens() {
+  const now = new Date();
+  try {
+    await Promise.all([
+      prisma.session.deleteMany({ where: { expires: { lt: now } } }),
+      prisma.verificationToken.deleteMany({ where: { expires: { lt: now } } }),
+      prisma.emailVerificationToken.deleteMany({ where: { expires: { lt: now } } }),
+      prisma.passwordResetToken.deleteMany({ where: { expires: { lt: now } } }),
+      prisma.adminSession.deleteMany({ where: { expiresAt: { lt: now } } }),
+    ]);
+    lastCleanupRun = Date.now();
+  } catch (error) {
+    console.error("Token cleanup error:", error);
+  }
+}
+
 export async function GET() {
   const checks = {
     api: "ok",
@@ -12,6 +33,11 @@ export async function GET() {
     // Test database connection
     await prisma.$queryRaw`SELECT 1`;
     checks.database = "ok";
+
+    // Run expired token cleanup if last run > 24h ago
+    if (Date.now() - lastCleanupRun > CLEANUP_INTERVAL_MS) {
+      cleanupExpiredTokens().catch((err) => console.error("Token cleanup error:", err));
+    }
   } catch (error) {
     console.error("Health check database error:", error);
     checks.database = "error";

--- a/src/lib/admin/auth.ts
+++ b/src/lib/admin/auth.ts
@@ -58,7 +58,7 @@ export async function adminLogin(
     }
 
     if (!adminUser.isActive) {
-      return { success: false, error: "Account is deactivated" };
+      return { success: false, error: "Invalid credentials" };
     }
 
     const isValid = await verifyPassword(password, adminUser.hashedPassword);
@@ -99,10 +99,12 @@ export async function adminLogin(
 
     // Set cookie
     const cookieStore = await cookies();
+    // Path remains "/" because admin pages make client-side fetches to /api/admin/*
+    // which doesn't match a /admin path prefix. SameSite strict prevents cross-site leakage.
     cookieStore.set(ADMIN_SESSION_COOKIE, token, {
       httpOnly: true,
       secure: process.env.NODE_ENV === "production",
-      sameSite: "lax",
+      sameSite: "strict",
       expires: expiresAt,
       path: "/",
     });

--- a/src/lib/mobile-auth.ts
+++ b/src/lib/mobile-auth.ts
@@ -20,8 +20,10 @@ const JWT_REFRESH_SECRET = process.env.JWT_REFRESH_SECRET || (() => {
   }
   return JWT_SECRET + "_REFRESH";
 })();
-const JWT_EXPIRY = "7d";
-const JWT_REFRESH_EXPIRY = "30d";
+// Short access token expiry mitigates stateless JWT revocation limitation.
+// Refresh tokens are longer-lived; revocation requires a future token blacklist.
+const JWT_EXPIRY = "15m";
+const JWT_REFRESH_EXPIRY = "7d";
 
 interface JWTPayload {
   userId: string;

--- a/src/lib/turnstile.ts
+++ b/src/lib/turnstile.ts
@@ -21,9 +21,13 @@ interface TurnstileVerifyResponse {
  * @returns Whether the verification succeeded
  */
 export async function verifyTurnstileToken(token: string, ip?: string): Promise<boolean> {
-  // If no secret key configured, skip verification (for development)
+  // In production, fail closed if secret key is not configured
   if (!TURNSTILE_SECRET_KEY) {
-    console.warn('TURNSTILE_SECRET_KEY not configured, skipping CAPTCHA verification');
+    if (process.env.NODE_ENV === "production") {
+      console.error('TURNSTILE_SECRET_KEY not configured in production — rejecting CAPTCHA');
+      return false;
+    }
+    console.warn('TURNSTILE_SECRET_KEY not configured, skipping CAPTCHA verification (dev only)');
     return true;
   }
 


### PR DESCRIPTION
M-01: Turnstile CAPTCHA fails closed in production when secret key missing
M-02: Registration/resend-verification return generic responses to prevent user enumeration
M-03: Console.log calls in auth.ts mask email addresses (first 2 chars + domain)
M-04: Admin session cookie uses sameSite strict (path stays / due to /api/admin architecture)
M-05: Password complexity requires 10+ chars, uppercase, lowercase, and number
M-06: Health endpoint triggers expired token/session cleanup every 24h
M-07: JWT access token expiry reduced from 7d to 15m, refresh from 30d to 7d
M-08: Admin login returns generic "Invalid credentials" for deactivated accounts
M-09: Inbound email webhook uses crypto.timingSafeEqual, secret is now required

Review fixes:
- Removed userId from web registration response to prevent enumeration oracle
- Removed user object from mobile registration response for same reason
- Removed env var guard around CAPTCHA call so turnstile.ts fail-closed logic is reached
- Health endpoint cleanup catch now logs errors instead of swallowing them

https://claude.ai/code/session_01BkxXAv4DEpWbXnzyS7Xtdk