### PR TITLE
Fix scan finding 0 tickers despite HIGH risk stocks in daily scan

### DIFF
--- a/src/lib/social-scan/get-scan-targets.ts
+++ b/src/lib/social-scan/get-scan-targets.ts
@@ -39,7 +39,6 @@ export async function getScanTargetsFromLatestDailyScan(
     where: {
       scanDate,
       riskLevel: 'HIGH',
-      isLegitimate: false,
       isInsufficient: false,
     },
     include: {

--- a/src/lib/social-scan/orchestrate.ts
+++ b/src/lib/social-scan/orchestrate.ts
@@ -33,10 +33,11 @@ function aggregateResults(
       }
     }
 
-    // Deduplicate by URL
+    // Deduplicate by URL (keep mentions without URLs)
     const seenUrls = new Set<string>();
     const uniqueMentions = tickerMentions.filter(m => {
-      if (!m.url || seenUrls.has(m.url)) return false;
+      if (!m.url) return true; // Keep mentions without URLs (e.g. StockTwits)
+      if (seenUrls.has(m.url)) return false;
       seenUrls.add(m.url);
       return true;
     });


### PR DESCRIPTION
The isLegitimate filter was excluding all stocks because the data ingestion pipeline defaults isLegitimate to true when not provided. HIGH risk stocks should always be scanned for social media promotion regardless of the legitimacy flag.

Also fixed deduplication silently dropping mentions without URLs (like StockTwits results).

https://claude.ai/code/session_01FqBJ59iskYPDipfCxtZujX