### PR TITLE
Migrate rate limiting from Upstash Redis to PostgreSQL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -62,10 +62,7 @@ STRIPE_PRICE_PAID_PLAN_ID="price_your-stripe-price-id"
 FREE_CHECKS_PER_MONTH="5"
 PAID_CHECKS_PER_MONTH="200"
 
-# Upstash Redis (for rate limiting)
-# Get URL and token from: https://console.upstash.com/redis
-UPSTASH_REDIS_REST_URL="https://your-redis.upstash.io"
-UPSTASH_REDIS_REST_TOKEN="your-upstash-redis-token"
+# Rate limiting uses PostgreSQL (via Prisma) — no additional config needed
 
 # Sentry (for error monitoring)
 # Get DSN from: https://sentry.io/

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,6 @@
         "@prisma/client": "^5.22.0",
         "@sentry/nextjs": "^10.32.1",
         "@supabase/supabase-js": "^2.93.1",
-        "@upstash/ratelimit": "^2.0.7",
-        "@upstash/redis": "^1.36.0",
         "@vercel/analytics": "^1.6.1",
         "@vercel/speed-insights": "^1.3.1",
         "autoprefixer": "^10.4.20",
@@ -4131,39 +4129,6 @@
       "os": [
         "win32"
       ]
-    },
-    "node_modules/@upstash/core-analytics": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/@upstash/core-analytics/-/core-analytics-0.0.10.tgz",
-      "integrity": "sha512-7qJHGxpQgQr9/vmeS1PktEwvNAF7TI4iJDi8Pu2CFZ9YUGHZH4fOP5TfYlZ4aVxfopnELiE4BS4FBjyK7V1/xQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@upstash/redis": "^1.28.3"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@upstash/ratelimit": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@upstash/ratelimit/-/ratelimit-2.0.7.tgz",
-      "integrity": "sha512-qNQW4uBPKVk8c4wFGj2S/vfKKQxXx1taSJoSGBN36FeiVBBKHQgsjPbKUijZ9Xu5FyVK+pfiXWKIsQGyoje8Fw==",
-      "license": "MIT",
-      "dependencies": {
-        "@upstash/core-analytics": "^0.0.10"
-      },
-      "peerDependencies": {
-        "@upstash/redis": "^1.34.3"
-      }
-    },
-    "node_modules/@upstash/redis": {
-      "version": "1.36.0",
-      "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.36.0.tgz",
-      "integrity": "sha512-9zN2UV9QJGPnXfWU3yZBLVQaqqENDh7g+Y4J2vJuSxBCi9FQ0aUOtaXlzuFhnsiZvCqM+eS27ic+tgmkWUsfOg==",
-      "license": "MIT",
-      "dependencies": {
-        "uncrypto": "^0.1.3"
-      }
     },
     "node_modules/@vercel/analytics": {
       "version": "1.6.1",
@@ -12633,12 +12598,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/uncrypto": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
-      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
-      "license": "MIT"
     },
     "node_modules/underscore": {
       "version": "1.13.7",

--- a/package.json
+++ b/package.json
@@ -20,8 +20,6 @@
     "@prisma/client": "^5.22.0",
     "@sentry/nextjs": "^10.32.1",
     "@supabase/supabase-js": "^2.93.1",
-    "@upstash/ratelimit": "^2.0.7",
-    "@upstash/redis": "^1.36.0",
     "@vercel/analytics": "^1.6.1",
     "@vercel/speed-insights": "^1.3.1",
     "autoprefixer": "^10.4.20",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -888,6 +888,18 @@ model BrowserEvidence {
   @@index([author])
 }
 
+model RateLimitEntry {
+  id         String   @id @default(cuid())
+  identifier String
+  tier       String
+  count      Int      @default(1)
+  window     DateTime
+  expiresAt  DateTime
+
+  @@unique([identifier, tier])
+  @@index([expiresAt])
+}
+
 model BrowserPlatformConfig {
   id                  String    @id @default(cuid())
   platform            String    @unique // discord, reddit, twitter, instagram, facebook, tiktok

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -39,8 +39,7 @@ export async function GET(request: Request) {
       NEXTAUTH_SECRET: !!process.env.NEXTAUTH_SECRET,
       AUTH_SECRET: !!process.env.AUTH_SECRET,
       NEXTAUTH_URL: process.env.NEXTAUTH_URL || "(not set)",
-      UPSTASH_REDIS_REST_URL: !!process.env.UPSTASH_REDIS_REST_URL,
-      UPSTASH_REDIS_REST_TOKEN: !!process.env.UPSTASH_REDIS_REST_TOKEN,
+      RATE_LIMIT: "PostgreSQL (via Prisma)",
     };
   }
 


### PR DESCRIPTION
## Summary
Replaces Upstash Redis-based rate limiting with a PostgreSQL-backed solution using Prisma, eliminating the need for external Redis infrastructure while maintaining the same rate limiting functionality.

## Key Changes
- **Removed Upstash Redis dependency**: Eliminated `@upstash/ratelimit` and `@upstash/redis` packages and all related initialization code
- **Added PostgreSQL rate limiting**: Implemented `prismaRateLimit()` function that uses a new `RateLimitEntry` table to track request counts per identifier and tier
- **Added database schema**: Created `RateLimitEntry` model with composite unique constraint on `(identifier, tier)` and index on `expiresAt` for cleanup
- **Graceful fallback**: Maintains in-memory rate limiting as a fallback when Prisma queries fail, with error logging
- **Updated configuration**: Added `windowMs` field to all rate limit configs for easier millisecond calculations
- **Simplified environment setup**: Removed requirement for `UPSTASH_REDIS_REST_URL` and `UPSTASH_REDIS_REST_TOKEN` environment variables
- **Updated health check**: Changed rate limiting status indicator from Redis environment variables to "PostgreSQL (via Prisma)"

## Implementation Details
- Rate limit entries are stored with a `window` timestamp and `expiresAt` expiration time
- The `prismaRateLimit()` function uses `upsert` to handle both new entries and window resets atomically
- In-memory fallback uses the same logic as before but now references `configValues.windowMs` for consistency
- Automatic cleanup of expired entries via existing interval-based cleanup mechanism
- The `isUsingRedis()` function now always returns `true` since PostgreSQL is the persistent store

https://claude.ai/code/session_01KQqBGQRRWwLn477Ms5b7un