### PR TITLE
Fix promotion detection: weighted scoring, lower thresholds, error lo…

### DIFF
--- a/src/lib/social-scan/orchestrate.ts
+++ b/src/lib/social-scan/orchestrate.ts
@@ -70,11 +70,11 @@ function aggregateResults(
     const highRiskPlatforms = platformsWithMentions.filter(p => {
       const pMentions = uniqueMentions.filter(m => m.platform === p);
       const avgScore = pMentions.reduce((s, m) => s + m.promotionScore, 0) / pMentions.length;
-      return avgScore >= 40;
+      return avgScore >= 25;
     });
 
     const riskLevel = highRiskPlatforms.length >= 2 ? 'high'
-      : highRiskPlatforms.length >= 1 || overallPromotionScore >= 50 ? 'medium' : 'low';
+      : highRiskPlatforms.length >= 1 || overallPromotionScore >= 30 ? 'medium' : 'low';
 
     let summary = '';
     if (uniqueMentions.length === 0) {


### PR DESCRIPTION
…gging

The scan system was finding 248+ mentions but only flagging 1 as promotional (0.19%) with avg score 2/100. Root causes:

1. Flat +10 per pattern match was too conservative — now weighted: HIGH (+20): guaranteed returns, insider info, act fast, pump and dump MEDIUM (+15): to the moon, squeeze, hidden gem, diamond hands LOW (+10): undervalued, dyor, price target

2. isPromotional thresholds were 25-30 across all scanners — lowered to 20

3. API errors in YouTube, Google CSE, and Perplexity were silently swallowed (if !res.ok continue) — now logs status code and response body

4. Perplexity citations were hardcoded to promotionScore: 0 — now scored

5. YouTube maxResults increased from 10 to 25 per ticker

6. Orchestration risk thresholds lowered:
   - High-risk platform avg: 40 → 25
   - Overall risk level: 50 → 30

7. New account bonus increased from +15 to +20
8. High engagement bonus gate lowered from score > 20 to score >= 10
9. Pattern library expanded from 26 to 60+ patterns

https://claude.ai/code/session_01NpRPrA1tbm5XrYGRv8YT1B