### PR TITLE
Fix scan 'Service unavailable' error: re-throw ServiceUnavailableErro…

### DIFF
--- a/src/app/HomeContent.tsx
+++ b/src/app/HomeContent.tsx
@@ -293,7 +293,7 @@ export default function HomeContent() {
           limitReached: true,
         });
       } else if (!response.ok) {
-        setError(responseData.error || "An error occurred");
+        setError(responseData.message || responseData.error || "An error occurred");
       } else {
         setResult(responseData as RiskResponse);
         setUsage(responseData.usage);

--- a/src/app/api/check/route.ts
+++ b/src/app/api/check/route.ts
@@ -176,6 +176,10 @@ async function callPythonAIBackend(
       } : undefined,
     };
   } catch (error) {
+    // Re-throw ServiceUnavailableError so the main handler can return a proper 503
+    if (error instanceof ServiceUnavailableError) {
+      throw error;
+    }
     const errMsg = error instanceof Error ? error.message : "Unknown error";
     console.error("AI backend call failed:", error);
     return { success: false, failReason: `Exception: ${errMsg}` };


### PR DESCRIPTION
…r and show user-friendly message

Two bugs caused scans to fail with an unhelpful 'service_unavailable' message:

1. callPythonAIBackend in check/route.ts swallowed ServiceUnavailableError instead of re-throwing it. When the Python backend returned 503 (data API down), the error was silently caught and the code fell through to the TypeScript fallback—which tried the same broken APIs, wasting the 30s time budget and likely causing a serverless timeout.

2. The frontend (HomeContent.tsx) displayed responseData.error (the machine- readable code "service_unavailable") instead of responseData.message (the human-friendly text). Users saw a raw error code rather than a clear explanation.

https://claude.ai/code/session_01D5ij78kEP9shjuuDkZ8rR8