### PR TITLE
Fix Reddit scanner returning 0 mentions and improve scanner diagnostics

### DIFF
--- a/.github/workflows/real-social-scan.yml
+++ b/.github/workflows/real-social-scan.yml
@@ -59,6 +59,10 @@ jobs:
       - name: Run Real Social Media Scan
         env:
           YOUTUBE_API_KEY: ${{ secrets.YOUTUBE_API_KEY }}
+          GOOGLE_CSE_API_KEY: ${{ secrets.GOOGLE_CSE_API_KEY }}
+          GOOGLE_CSE_ID: ${{ secrets.GOOGLE_CSE_ID }}
+          PERPLEXITY_API_KEY: ${{ secrets.PERPLEXITY_API_KEY }}
+          DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
           STOCKS: ${{ github.event.inputs.stocks }}
         run: |
           cd evaluation

--- a/evaluation/scripts/social-scan/reddit-oauth-scanner.ts
+++ b/evaluation/scripts/social-scan/reddit-oauth-scanner.ts
@@ -73,7 +73,7 @@ async function searchRedditForTicker(
 
   for (const query of queries) {
     try {
-      const url = `https://www.reddit.com/search.json?q=${encodeURIComponent(query)}&sort=new&t=week&limit=25&type=link`;
+      const url = `https://www.reddit.com/search.json?q=${encodeURIComponent(query)}&sort=new&t=week&limit=25`;
       const data = await redditPublicGet(url);
 
       const posts = data?.data?.children || [];


### PR DESCRIPTION
- Remove type=link filter from Reddit search URL — this was excluding self/text posts where most penny stock discussions happen, causing Reddit to silently return 0 results
- Fix applied to both admin dashboard scanner (src/lib) and evaluation CLI scanner (evaluation/scripts)
- Add diagnostic logging to getConfiguredScanners() showing which scanners are active vs skipped with the missing env var names
- Pass all social scan API keys through GitHub Actions workflow (previously only YOUTUBE_API_KEY was forwarded)

https://claude.ai/code/session_01NpRPrA1tbm5XrYGRv8YT1B