### PR TITLE
Fix daily scan crash: re-export calculatePlatformSpecificScore from t…

### DIFF
--- a/evaluation/scripts/social-scan/types.ts
+++ b/evaluation/scripts/social-scan/types.ts
@@ -2,6 +2,9 @@
  * Shared types for the Social Media Scanning System
  */
 
+// Re-export platform-specific scoring so scanners can import from './types'
+export { calculatePlatformSpecificScore } from './platform-patterns';
+
 // Input: what we're scanning for
 export interface ScanTarget {
   ticker: string;


### PR DESCRIPTION
…ypes.ts

The pump detection overhaul (afce482) added calculatePlatformSpecificScore to platform-patterns.ts but all 5 scanner files import it from types.ts. At runtime ts-node silently imports undefined, crashing Phase 4 with TypeError: calculatePlatformSpecificScore is not a function.

https://claude.ai/code/session_01T4GC1L8tq1VBzbGAtiPwX8