### PR TITLE
Fix invalid workflow: remove secrets context from if expression

### DIFF
--- a/.github/workflows/post-scan-processing.yml
+++ b/.github/workflows/post-scan-processing.yml
@@ -145,7 +145,6 @@ jobs:
           echo "Uploaded $UPLOADED files to Supabase"
 
       - name: Checkout data repository
-        if: ${{ secrets.DATA_REPO_TOKEN != '' }}
         continue-on-error: true
         id: checkout-data
         uses: actions/checkout@v4


### PR DESCRIPTION
GitHub Actions does not allow `secrets` in `if` conditions, making the entire post-scan-processing.yml unparseable. Remove the guard and rely on `continue-on-error: true` (already present) plus the existing `steps.checkout-data.outcome == 'success'` checks on downstream steps.

https://claude.ai/code/session_01T4GC1L8tq1VBzbGAtiPwX8