### PR TITLE
fix: daily scan pipeline TypeScript compilation error

### DIFF
--- a/evaluation/scripts/enhanced-daily-pipeline.ts
+++ b/evaluation/scripts/enhanced-daily-pipeline.ts
@@ -1740,14 +1740,16 @@ async function runEnhancedPipeline(): Promise<void> {
                   promotionScore: m.promotionScore || 0,
                   redFlags: m.redFlags || [],
                 })),
-                overallActivityLevel:
-                  mentions.length >= 5
-                    ? "high"
-                    : mentions.length >= 2
-                      ? "medium"
-                      : "low",
-                promotionRisk:
-                  platAvg >= 60 ? "high" : platAvg >= 30 ? "medium" : "low",
+                overallActivityLevel: (mentions.length >= 5
+                  ? "high"
+                  : mentions.length >= 2
+                    ? "medium"
+                    : "low") as "high" | "medium" | "low",
+                promotionRisk: (platAvg >= 60
+                  ? "high"
+                  : platAvg >= 30
+                    ? "medium"
+                    : "low") as "high" | "medium" | "low",
                 error: null,
               };
             },


### PR DESCRIPTION
## Summary
- Fixed TypeScript type mismatch in `enhanced-daily-pipeline.ts` line 1791 that has been **crashing all daily scans since March 17**
- The `overallActivityLevel` and `promotionRisk` ternary expressions returned `string` instead of the required union literal types (`"high" | "medium" | "low"`)
- Added type assertions to match `PlatformScanResult` interface
- This also fixes social scans, which are Phase 5 and never trigger when the pipeline crashes at compile time

## Impact
- **4 consecutive weekday scan failures** (Mar 17-20) — zero stocks evaluated, zero social scans
- One-line fix, zero behavioral changes

## Test plan
- [x] `npx tsc --noEmit` passes cleanly
- [ ] Verify Vercel preview deployment builds
- [ ] Merge to main, then manually trigger workflow with `date_override` to confirm end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)