### PR TITLE
fix(railway): remove TensorFlow from default Docker build to fix OOM build failure

### DIFF
--- a/python_ai/Dockerfile
+++ b/python_ai/Dockerfile
@@ -1,61 +1,43 @@
 # Python AI Backend Dockerfile
-# Provides full ML models: Random Forest, LSTM, Anomaly Detection
-# Updated: Force rebuild with TensorFlow
+# Rules-based scoring + optional ML models (Random Forest, LSTM, Anomaly Detection).
+# TensorFlow is NOT installed here — it is only needed when ML_MODELS_ENABLED=true,
+# which requires retraining on real data first (disabled by default).
+# To enable ML: install requirements-ml.txt on top of this image.
 
 FROM python:3.11-slim
 
-# Set working directory
 WORKDIR /app
 
-# Environment variables for TensorFlow - memory optimization
-ENV TF_CPP_MIN_LOG_LEVEL=2
 ENV PYTHONUNBUFFERED=1
 ENV PIP_DEFAULT_TIMEOUT=300
-# Limit TensorFlow memory usage
-ENV TF_FORCE_GPU_ALLOW_GROWTH=true
-ENV TF_ENABLE_ONEDNN_OPTS=0
-ENV OMP_NUM_THREADS=1
-ENV TF_NUM_INTEROP_THREADS=1
-ENV TF_NUM_INTRAOP_THREADS=1
-# Disable GPU (use CPU only for Railway)
-ENV CUDA_VISIBLE_DEVICES=-1
 
-# Install system dependencies
+# gcc/g++ needed for scikit-learn C extensions; curl for health probes
 RUN apt-get update && apt-get install -y \
     gcc \
     g++ \
     curl \
-    libhdf5-dev \
-    pkg-config \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy requirements first for better caching
+# Copy requirements first for better layer caching
 COPY requirements.txt .
 
-# Install Python dependencies - force no cache to ensure TensorFlow installs
-RUN pip install --no-cache-dir --timeout 300 -r requirements.txt && \
-    python -c "import tensorflow; print('TensorFlow version:', tensorflow.__version__)"
+RUN pip install --no-cache-dir --timeout 300 -r requirements.txt
 
 # Copy application code
 COPY . .
 
-# Create models directory if not exists (models are pre-trained and included)
 RUN mkdir -p models
 
-# Verify the app can be imported
+# Verify the app imports cleanly (no TF needed at import time — it is lazy)
 RUN python -c "from api_server import app; print('App imported successfully')"
 
-# Create non-root user for runtime security
+# Non-root runtime user
 RUN adduser --disabled-password --gecos "" appuser \
     && mkdir -p /home/appuser/.cache \
     && chown -R appuser:appuser /app /home/appuser
 USER appuser
 
-# Set default port (Railway will override with $PORT)
 ENV PORT=8000
-
-# Expose port
 EXPOSE 8000
 
-# Run the API server with gunicorn (more robust for production)
 CMD ["sh", "-c", "gunicorn api_server:app --bind 0.0.0.0:$PORT --worker-class uvicorn.workers.UvicornWorker --workers ${GUNICORN_WORKERS:-1} --timeout 300 --keep-alive 5 --access-logfile - --error-logfile -"]

--- a/python_ai/requirements-ml.txt
+++ b/python_ai/requirements-ml.txt
@@ -1,0 +1,17 @@
+# ML-enabled build requirements — install ON TOP of requirements.txt.
+# Only needed when ML_MODELS_ENABLED=true (after retraining models on real data).
+#
+# Usage:
+#   pip install -r requirements.txt
+#   pip install -r requirements-ml.txt
+#
+# Railway: set ML_MODELS_ENABLED=true AND swap the Dockerfile CMD to use
+# gunicorn with both requirements files installed.
+
+-r requirements.txt
+
+# Deep learning (LSTM model)
+tensorflow==2.15.0
+
+# HDF5 for Keras model save/load
+h5py>=3.10.0

--- a/python_ai/requirements.txt
+++ b/python_ai/requirements.txt
@@ -3,10 +3,9 @@ numpy==1.24.0
 pandas==2.0.0
 scikit-learn==1.3.0
 
-# Deep Learning - Full TensorFlow for LSTM model.
-# Only needed when ML_MODELS_ENABLED=true (models off by default until retrained
-# on real data). Keep here for the ML-enabled deployment path.
-tensorflow==2.15.0
+# TensorFlow (LSTM model) is NOT included here — it is only needed when
+# ML_MODELS_ENABLED=true, which requires retraining on real data first.
+# Install requirements-ml.txt on top of this file to add TF for ML-enabled builds.
 
 # Data handling
 # Bumped off the 2-year-old 0.2.30 pin (predates Yahoo's 2024-25 cookie/crumb


### PR DESCRIPTION
## Problem

Railway was failing to build the Python AI Docker image because the `Dockerfile` ran `python -c "import tensorflow"` **during the build**. Importing TF loads ~500 MB of native libraries into RAM — this OOMs Railway's build containers and kills the build.

## Fix

- **Removed** TF from `requirements.txt` (it was already guarded by `# Only needed when ML_MODELS_ENABLED=true`)
- **Removed** the `&& python -c "import tensorflow..."` verification step from `Dockerfile`
- **Removed** TF-specific apt packages (`libhdf5-dev`, `pkg-config`) and ENV vars from `Dockerfile`
- **Added** `requirements-ml.txt` for the future ML-enabled path (install on top of `requirements.txt` when models are retrained)

## Impact

- Zero change to runtime behaviour: TF is already lazy-loaded (`tf = None` at module level in `lstm_model.py`) and only activates when `ML_MODELS_ENABLED=true`, which is `false` by default
- Docker image shrinks by ~500 MB
- Railway build will now complete successfully

---
_Generated by [Claude Code](https://claude.ai/code/session_015BXHEkzHFELZypri8eEqKN)_