### PR TITLE
fix: rate-limit store failure no longer locks out all logins

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -5,7 +5,9 @@
       "Bash(npx skills add:*)",
       "WebFetch(domain:scamdunk.com)",
       "Bash(curl:*)",
-      "mcp__Vercel__get_runtime_logs"
+      "mcp__Vercel__get_runtime_logs",
+      "mcp__Supabase__get_project",
+      "mcp__Supabase__get_logs"
     ]
   }
 }

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -74,6 +74,19 @@ const FAIL_CLOSED_TIERS: ReadonlySet<RateLimitConfig> = new Set<RateLimitConfig>
 );
 
 /**
+ * Thrown when the shared rate-limit store fails for a fail-closed tier
+ * (strict/auth). The caller — checkLoginRateLimit — catches this and fails
+ * open so a transient DB timeout doesn't permanently lock out all logins.
+ */
+export class RateLimitStoreError extends Error {
+  constructor(cause: unknown) {
+    super("Rate-limit store unavailable");
+    this.name = "RateLimitStoreError";
+    this.cause = cause;
+  }
+}
+
+/**
  * Get client identifier from request
  * Prioritizes Vercel's trusted x-real-ip header to prevent spoofing via x-forwarded-for
  */
@@ -282,14 +295,11 @@ export async function rateLimit(
     );
 
     if (FAIL_CLOSED_TIERS.has(config)) {
-      // Fail closed: deny brute-force-sensitive tiers when the shared store is
-      // down, instead of granting each cold instance a fresh allowance.
-      const configValues = rateLimitConfigs[config];
-      result = {
-        success: false,
-        remaining: 0,
-        reset: Date.now() + configValues.windowMs,
-      };
+      // Throw so callers that wrap us in their own try/catch (e.g.
+      // checkLoginRateLimit) can distinguish a store outage from a legitimate
+      // rate-limit hit and choose to fail open — preventing a transient DB
+      // timeout from permanently locking out all logins.
+      throw new RateLimitStoreError(error);
     } else {
       result = inMemoryRateLimit(identifier, config);
     }


### PR DESCRIPTION
## Summary

- **Root cause**: When the Prisma rate-limit check threw a transient error (e.g. DB cold-start timeout), the fail-closed path returned `{success: false}` silently — without throwing. `checkLoginRateLimit`'s safety-net `catch` never fired, so every login showed "Too many login attempts" indefinitely, even in incognito.
- **Fix**: The fail-closed path now throws `RateLimitStoreError` instead of returning `{success: false}`. This propagates up to `checkLoginRateLimit`'s existing `catch` block, which logs it and returns `true` (fail open) — matching the original design intent.
- Real rate limits (legitimate brute-force blocking) are unaffected.

## Test plan

- [ ] Run `DELETE FROM "RateLimitEntry" WHERE tier = 'strict';` in Supabase SQL Editor to clear stuck entries
- [ ] Confirm login works immediately after clearing entries
- [ ] Confirm that 5+ rapid login attempts still trigger "Too many login attempts" (rate limiting still works)
- [ ] Confirm that waiting ~60 seconds after being rate-limited resets the counter

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BXHEkzHFELZypri8eEqKN

---
_Generated by [Claude Code](https://claude.ai/code/session_015BXHEkzHFELZypri8eEqKN)_