### PR TITLE
feat: add paid WhatsApp stock scans

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -6,6 +6,9 @@ const config = {
     "^@/(.*)$": "<rootDir>/src/$1",
   },
   testMatch: ["**/*.test.ts"],
+  // Scoring integration cases intentionally exercise bounded external-data
+  // fallbacks; 5s is occasionally shorter than their documented timeout.
+  testTimeout: 10000,
   collectCoverageFrom: ["src/lib/**/*.ts", "!src/lib/**/*.d.ts"],
 };
 

--- a/prisma/migrations/20260809000000_whatsapp_scan_mvp/migration.sql
+++ b/prisma/migrations/20260809000000_whatsapp_scan_mvp/migration.sql
@@ -1,0 +1,45 @@
+CREATE TABLE "WhatsAppIdentityBinding" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "identityHash" TEXT NOT NULL,
+    "identityEncrypted" TEXT NOT NULL,
+    "active" BOOLEAN NOT NULL DEFAULT false,
+    "verificationCodeHash" TEXT,
+    "verificationExpiresAt" TIMESTAMP(3),
+    "verificationAttempts" INTEGER NOT NULL DEFAULT 0,
+    "lastVerificationSentAt" TIMESTAMP(3),
+    "bindingVersion" TEXT NOT NULL DEFAULT 'web-template-v1',
+    "boundAt" TIMESTAMP(3),
+    "revokedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "WhatsAppIdentityBinding_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "WhatsAppInboundEvent" (
+    "id" TEXT NOT NULL,
+    "providerMessageId" TEXT NOT NULL,
+    "senderIdentityHash" TEXT NOT NULL,
+    "bindingId" TEXT,
+    "messageType" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'RECEIVED',
+    "reasonCode" TEXT,
+    "encryptedText" TEXT,
+    "encryptedReply" TEXT,
+    "senderIdentityEncrypted" TEXT,
+    "providerReplyMessageId" TEXT,
+    "attemptCount" INTEGER NOT NULL DEFAULT 0,
+    "processedAt" TIMESTAMP(3),
+    "purgeAt" TIMESTAMP(3) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "WhatsAppInboundEvent_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "WhatsAppIdentityBinding_identityHash_key" ON "WhatsAppIdentityBinding"("identityHash");
+CREATE INDEX "WhatsAppIdentityBinding_userId_active_idx" ON "WhatsAppIdentityBinding"("userId", "active");
+CREATE UNIQUE INDEX "WhatsAppInboundEvent_providerMessageId_key" ON "WhatsAppInboundEvent"("providerMessageId");
+CREATE INDEX "WhatsAppInboundEvent_senderIdentityHash_createdAt_idx" ON "WhatsAppInboundEvent"("senderIdentityHash", "createdAt");
+CREATE INDEX "WhatsAppInboundEvent_status_purgeAt_idx" ON "WhatsAppInboundEvent"("status", "purgeAt");
+ALTER TABLE "WhatsAppIdentityBinding" ADD CONSTRAINT "WhatsAppIdentityBinding_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "WhatsAppInboundEvent" ADD CONSTRAINT "WhatsAppInboundEvent_bindingId_fkey" FOREIGN KEY ("bindingId") REFERENCES "WhatsAppIdentityBinding"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -35,6 +35,7 @@ model User {
   accounts   Account[]
   sessions   Session[]
   scanUsages ScanUsage[]
+  whatsAppIdentityBindings WhatsAppIdentityBinding[]
 }
 
 // TODO [H-11]: OAuth tokens (refresh_token, access_token, id_token) are stored in plain text.
@@ -111,6 +112,56 @@ model ScanUsage {
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@unique([userId, monthKey])
+}
+
+// WhatsApp sender identity is never stored in clear text. identityHash is an
+// HMAC lookup key and identityEncrypted is protected with a dedicated key.
+model WhatsAppIdentityBinding {
+  id                    String   @id @default(cuid())
+  userId                String
+  identityHash          String   @unique
+  identityEncrypted     String   @db.Text
+  active                Boolean  @default(false)
+  verificationCodeHash  String?
+  verificationExpiresAt DateTime?
+  verificationAttempts  Int      @default(0)
+  lastVerificationSentAt DateTime?
+  bindingVersion        String   @default("web-template-v1")
+  boundAt               DateTime?
+  revokedAt             DateTime?
+  createdAt             DateTime @default(now())
+  updatedAt             DateTime @updatedAt
+
+  user          User                    @relation(fields: [userId], references: [id], onDelete: Cascade)
+  inboundEvents WhatsAppInboundEvent[]
+
+  @@index([userId, active])
+}
+
+// Minimal durable idempotency ledger. Raw inbound text is encrypted only while
+// an event is pending/retryable and is purged on the scheduled retention date.
+model WhatsAppInboundEvent {
+  id                   String   @id @default(cuid())
+  providerMessageId    String   @unique
+  senderIdentityHash   String
+  bindingId            String?
+  messageType          String
+  status               String   @default("RECEIVED")
+  reasonCode           String?
+  encryptedText        String?  @db.Text
+  encryptedReply       String?  @db.Text
+  senderIdentityEncrypted String? @db.Text
+  providerReplyMessageId String?
+  attemptCount         Int      @default(0)
+  processedAt          DateTime?
+  purgeAt              DateTime
+  createdAt            DateTime @default(now())
+  updatedAt            DateTime @updatedAt
+
+  binding WhatsAppIdentityBinding? @relation(fields: [bindingId], references: [id], onDelete: SetNull)
+
+  @@index([senderIdentityHash, createdAt])
+  @@index([status, purgeAt])
 }
 
 // ==========================================

--- a/src/app/(protected)/account/page.tsx
+++ b/src/app/(protected)/account/page.tsx
@@ -25,6 +25,7 @@ import {
   AlertTriangle,
   Calendar,
   XCircle,
+  MessageCircle,
 } from "lucide-react";
 import { UsageInfo } from "@/lib/types";
 import { useToast } from "@/components/ui/toast";
@@ -36,6 +37,11 @@ interface SubscriptionInfo {
   status?: string;
   nextBillingDate?: string;
   startDate?: string;
+}
+
+interface WhatsAppBindingStatus {
+  active: boolean;
+  maskedPhone?: string;
 }
 
 function AccountAlerts() {
@@ -101,6 +107,18 @@ function AccountContent() {
   const [showCancelConfirm, setShowCancelConfirm] = useState(false);
   const [isCancelling, setIsCancelling] = useState(false);
 
+  // WhatsApp account linking (the code is entered here, never in chat).
+  const [whatsAppBinding, setWhatsAppBinding] =
+    useState<WhatsAppBindingStatus | null>(null);
+  const [isLoadingWhatsApp, setIsLoadingWhatsApp] = useState(true);
+  const [whatsAppPhone, setWhatsAppPhone] = useState("");
+  const [whatsAppCode, setWhatsAppCode] = useState("");
+  const [isSendingWhatsAppCode, setIsSendingWhatsAppCode] = useState(false);
+  const [isConfirmingWhatsApp, setIsConfirmingWhatsApp] = useState(false);
+  const [isRevokingWhatsApp, setIsRevokingWhatsApp] = useState(false);
+  const [whatsAppError, setWhatsAppError] = useState("");
+  const [whatsAppCodeSent, setWhatsAppCodeSent] = useState(false);
+
   // Account deletion
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [deletePassword, setDeletePassword] = useState("");
@@ -119,6 +137,7 @@ function AccountContent() {
     if (session?.user?.id) {
       fetchUsage();
       fetchSubscriptionInfo();
+      fetchWhatsAppBinding();
       setEditName(session.user.name || "");
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -155,6 +174,81 @@ function AccountContent() {
       console.error("Failed to fetch subscription info:", err);
     } finally {
       setIsLoadingSubscription(false);
+    }
+  };
+
+  const fetchWhatsAppBinding = async () => {
+    setIsLoadingWhatsApp(true);
+    try {
+      const response = await fetch("/api/user/whatsapp");
+      if (!response.ok) throw new Error("Unable to load WhatsApp status");
+      setWhatsAppBinding(await response.json());
+    } catch {
+      setWhatsAppError("Couldn’t load WhatsApp access. Try again.");
+    } finally {
+      setIsLoadingWhatsApp(false);
+    }
+  };
+
+  const handleSendWhatsAppCode = async () => {
+    setIsSendingWhatsAppCode(true);
+    setWhatsAppError("");
+    try {
+      const response = await fetch("/api/user/whatsapp", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "begin", phoneNumber: whatsAppPhone }),
+      });
+      const data = await response.json();
+      if (!response.ok) throw new Error(data.error);
+      setWhatsAppCodeSent(true);
+      addToast({
+        type: "success",
+        title: "Verification code sent",
+        description: `Enter the code sent to ${data.maskedPhone} here to finish linking.`,
+      });
+    } catch (error) {
+      setWhatsAppError(error instanceof Error ? error.message : "Couldn’t send a code. Try again.");
+    } finally {
+      setIsSendingWhatsAppCode(false);
+    }
+  };
+
+  const handleConfirmWhatsAppCode = async () => {
+    setIsConfirmingWhatsApp(true);
+    setWhatsAppError("");
+    try {
+      const response = await fetch("/api/user/whatsapp", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "confirm", code: whatsAppCode }),
+      });
+      const data = await response.json();
+      if (!response.ok) throw new Error(data.error);
+      setWhatsAppBinding({ active: true, maskedPhone: data.maskedPhone });
+      setWhatsAppCode("");
+      setWhatsAppPhone("");
+      setWhatsAppCodeSent(false);
+      addToast({ type: "success", title: "WhatsApp linked", description: "Send AAPL or scan AAPL to ScamDunk to run a stock scan." });
+    } catch (error) {
+      setWhatsAppError(error instanceof Error ? error.message : "Couldn’t verify the code. Try again.");
+    } finally {
+      setIsConfirmingWhatsApp(false);
+    }
+  };
+
+  const handleRevokeWhatsApp = async () => {
+    setIsRevokingWhatsApp(true);
+    setWhatsAppError("");
+    try {
+      const response = await fetch("/api/user/whatsapp", { method: "DELETE" });
+      if (!response.ok) throw new Error("Couldn’t unlink WhatsApp. Try again.");
+      setWhatsAppBinding({ active: false });
+      addToast({ type: "success", title: "WhatsApp unlinked", description: "This number can no longer request ScamDunk scans." });
+    } catch (error) {
+      setWhatsAppError(error instanceof Error ? error.message : "Couldn’t unlink WhatsApp. Try again.");
+    } finally {
+      setIsRevokingWhatsApp(false);
     }
   };
 
@@ -792,6 +886,40 @@ function AccountContent() {
                     </div>
                   )}
                 </div>
+              )}
+            </CardContent>
+          </Card>
+
+          {/* WhatsApp scan access */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <MessageCircle className="h-5 w-5" />
+                WhatsApp scans
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <p className="text-sm text-muted-foreground">
+                Link one WhatsApp number to send a stock ticker for a ScamDunk scan. Only <span className="font-medium text-foreground">AAPL</span> or <span className="font-medium text-foreground">scan AAPL</span> are supported.
+              </p>
+              {isLoadingWhatsApp ? (
+                <div className="flex items-center gap-2 text-sm text-muted-foreground"><Loader2 className="h-4 w-4 animate-spin" /> Loading WhatsApp access…</div>
+              ) : whatsAppError ? (
+                <Alert variant="destructive"><AlertDescription className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between"><span>{whatsAppError}</span><Button variant="outline" size="sm" onClick={() => { setWhatsAppError(""); fetchWhatsAppBinding(); }}>Retry</Button></AlertDescription></Alert>
+              ) : whatsAppBinding?.active ? (
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between rounded-lg border p-3">
+                  <div><p className="font-medium">Linked {whatsAppBinding.maskedPhone ? `to ${whatsAppBinding.maskedPhone}` : ""}</p><p className="text-sm text-muted-foreground">Scans still use your current monthly ScamDunk allowance.</p></div>
+                  <Button variant="outline" onClick={handleRevokeWhatsApp} disabled={isRevokingWhatsApp}>{isRevokingWhatsApp ? <><Loader2 className="mr-2 h-4 w-4 animate-spin" />Unlinking…</> : "Unlink WhatsApp"}</Button>
+                </div>
+              ) : usage?.plan !== "PAID" ? (
+                <Alert><AlertDescription>An active ScamDunk subscription is required before you can link WhatsApp.</AlertDescription></Alert>
+              ) : whatsAppCodeSent ? (
+                <div className="space-y-3">
+                  <div className="space-y-2"><Label htmlFor="whatsapp-code">Six-digit verification code</Label><Input id="whatsapp-code" inputMode="numeric" autoComplete="one-time-code" maxLength={6} value={whatsAppCode} onChange={(event) => setWhatsAppCode(event.target.value.replace(/\D/g, ""))} placeholder="123456" disabled={isConfirmingWhatsApp} /></div>
+                  <div className="flex flex-col gap-2 sm:flex-row"><Button onClick={handleConfirmWhatsAppCode} disabled={isConfirmingWhatsApp || whatsAppCode.length !== 6}>{isConfirmingWhatsApp ? <><Loader2 className="mr-2 h-4 w-4 animate-spin" />Verifying…</> : "Verify and link"}</Button><Button variant="outline" onClick={() => { setWhatsAppCodeSent(false); setWhatsAppCode(""); }}>Use another number</Button></div>
+                </div>
+              ) : (
+                <div className="space-y-3"><div className="space-y-2"><Label htmlFor="whatsapp-phone">WhatsApp phone number</Label><Input id="whatsapp-phone" type="tel" inputMode="tel" autoComplete="tel" value={whatsAppPhone} onChange={(event) => setWhatsAppPhone(event.target.value)} placeholder="+12125550199" disabled={isSendingWhatsAppCode} /><p className="text-xs text-muted-foreground">Use international format. We’ll send a one-time code to this WhatsApp chat; enter it on this page.</p></div><Button onClick={handleSendWhatsAppCode} disabled={isSendingWhatsAppCode || !whatsAppPhone}>{isSendingWhatsAppCode ? <><Loader2 className="mr-2 h-4 w-4 animate-spin" />Sending code…</> : "Send verification code"}</Button></div>
               )}
             </CardContent>
           </Card>

--- a/src/app/api/check/route.ts
+++ b/src/app/api/check/route.ts
@@ -253,7 +253,16 @@ async function callPythonAIBackend(
   }
 }
 
-export async function POST(request: NextRequest) {
+export type AuthorizedStockScanRequest = {
+  userId: string;
+  ticker: string;
+  assetType: "stock";
+};
+
+async function processCheckRequest(
+  request: NextRequest,
+  authenticatedUserId?: string,
+) {
   const startTime = Date.now();
   let currentStep = "INIT";
   // Tracks whether a quota slot has been reserved, so the error path can refund
@@ -280,12 +289,14 @@ export async function POST(request: NextRequest) {
 
     // Check authentication - support both session (web) and JWT (mobile)
     currentStep = "AUTH";
-    let userId: string | null = null;
-    const session = await auth();
-    if (session?.user?.id) {
-      userId = session.user.id;
-    } else {
-      userId = await authenticateMobileRequest(request);
+    let userId: string | null = authenticatedUserId ?? null;
+    if (!userId) {
+      const session = await auth();
+      if (session?.user?.id) {
+        userId = session.user.id;
+      } else {
+        userId = await authenticateMobileRequest(request);
+      }
     }
 
     if (!userId) {
@@ -595,4 +606,32 @@ export async function POST(request: NextRequest) {
       { status: 500 },
     );
   }
+}
+
+/**
+ * Server-only adapter used by trusted channels. It calls the same in-process
+ * scan operation as the web route, never loops back through public HTTP, and
+ * deliberately offers no way to supply pitch text or client context.
+ */
+export async function runAuthorizedStockScan(
+  input: AuthorizedStockScanRequest,
+) {
+  const request = new NextRequest("http://internal/api/check", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-real-ip": `whatsapp:${input.userId}`,
+    },
+    body: JSON.stringify({ ticker: input.ticker, assetType: input.assetType }),
+  });
+  const response = await processCheckRequest(request, input.userId);
+  const body = await response.json();
+  if (!response.ok) {
+    return { ok: false as const, status: response.status, body };
+  }
+  return { ok: true as const, body: body as RiskResponse };
+}
+
+export async function POST(request: NextRequest) {
+  return processCheckRequest(request);
 }

--- a/src/app/api/cron/whatsapp-retention/route.ts
+++ b/src/app/api/cron/whatsapp-retention/route.ts
@@ -1,0 +1,50 @@
+import crypto from "crypto";
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/db";
+import { processWhatsAppInboundEvent } from "@/lib/whatsapp/processor";
+
+export const dynamic = "force-dynamic";
+
+function authorized(request: NextRequest): boolean {
+  const expected = process.env.CRON_SECRET;
+  const token = request.headers.get("authorization")?.replace(/^Bearer\s+/i, "");
+  if (!expected || !token || expected.length !== token.length) return false;
+  return crypto.timingSafeEqual(Buffer.from(expected), Buffer.from(token));
+}
+
+export async function GET(request: NextRequest) {
+  if (!authorized(request)) return new NextResponse("Unauthorized", { status: 401 });
+  const now = new Date();
+  const retryBefore = new Date(now.getTime() - 60_000);
+  const scanBefore = new Date(now.getTime() - 5 * 60_000);
+  const retryEvents = await prisma.whatsAppInboundEvent.findMany({
+    where: {
+      OR: [
+        { status: "RECEIVED", createdAt: { lte: retryBefore } },
+        { status: "RETRY", updatedAt: { lte: retryBefore } },
+        { status: "SENDING", updatedAt: { lte: retryBefore } },
+      ],
+      attemptCount: { lt: 3 },
+      purgeAt: { gt: now },
+    },
+    select: { id: true },
+    take: 25,
+    orderBy: { updatedAt: "asc" },
+  });
+  for (const event of retryEvents) await processWhatsAppInboundEvent(event.id);
+  const deadLettered = await prisma.whatsAppInboundEvent.updateMany({
+    where: {
+      OR: [
+        { status: "RETRY", attemptCount: { gte: 3 } },
+        { status: "PROCESSING", updatedAt: { lte: scanBefore } },
+        { status: "SCANNING", updatedAt: { lte: scanBefore } },
+      ],
+    },
+    data: { status: "FAILED", reasonCode: "RETRY_EXHAUSTED" },
+  });
+  const purged = await prisma.whatsAppInboundEvent.updateMany({
+    where: { purgeAt: { lte: now } },
+    data: { encryptedText: null, encryptedReply: null, senderIdentityEncrypted: null },
+  });
+  return NextResponse.json({ retried: retryEvents.length, deadLettered: deadLettered.count, purged: purged.count });
+}

--- a/src/app/api/user/whatsapp/route.ts
+++ b/src/app/api/user/whatsapp/route.ts
@@ -1,0 +1,98 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { auth } from "@/lib/auth";
+import { rateLimit } from "@/lib/rate-limit";
+import {
+  beginWhatsAppBinding,
+  confirmWhatsAppBinding,
+  getWhatsAppBindingStatus,
+  isCurrentWhatsAppSubscriber,
+  revokeWhatsAppBinding,
+} from "@/lib/whatsapp/binding";
+
+export const dynamic = "force-dynamic";
+
+const beginSchema = z.object({ action: z.literal("begin"), phoneNumber: z.string().max(32) });
+const confirmSchema = z.object({ action: z.literal("confirm"), code: z.string().regex(/^\d{6}$/) });
+
+async function sessionUserId(): Promise<string | null> {
+  const session = await auth();
+  return session?.user?.id ?? null;
+}
+
+function errorMessage(code: string): string {
+  const messages: Record<string, string> = {
+    INVALID_PHONE: "Enter a valid phone number in international format, for example +12125550199.",
+    NUMBER_IN_USE: "That WhatsApp number cannot be linked to this account.",
+    NOT_ENTITLED: "An active ScamDunk subscription is required to link WhatsApp.",
+    TOO_SOON: "A code was sent recently. Wait a minute before requesting another.",
+    INVALID_CODE: "That code is not valid. Check the code and try again.",
+    EXPIRED_CODE: "That code has expired. Request a new one.",
+    UNAVAILABLE: "WhatsApp linking is temporarily unavailable. Please try again later.",
+  };
+  return messages[code] ?? "WhatsApp linking is temporarily unavailable. Please try again later.";
+}
+
+async function allowBindingCodeSend(request: NextRequest, userId: string): Promise<boolean> {
+  const userRequest = new NextRequest("http://internal/whatsapp-binding", {
+    headers: { "x-real-ip": `whatsapp-binding-user:${userId}` },
+  });
+  const globalRequest = new NextRequest("http://internal/whatsapp-binding", {
+    headers: { "x-real-ip": "whatsapp-binding-global" },
+  });
+  const [byUser, byIp, global] = await Promise.all([
+    rateLimit(userRequest, "whatsappBindingUser"),
+    rateLimit(request, "whatsappBindingIp"),
+    rateLimit(globalRequest, "whatsappBindingGlobal"),
+  ]);
+  return byUser.success && byIp.success && global.success;
+}
+
+export async function GET() {
+  const userId = await sessionUserId();
+  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  try {
+    return NextResponse.json(await getWhatsAppBindingStatus(userId));
+  } catch {
+    return NextResponse.json({ error: "Unable to load WhatsApp status" }, { status: 503 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const userId = await sessionUserId();
+  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const body = await request.json().catch(() => null);
+  const begin = beginSchema.safeParse(body);
+  const confirm = confirmSchema.safeParse(body);
+  if (begin.success) {
+    try {
+      if (!(await isCurrentWhatsAppSubscriber(userId))) {
+        return NextResponse.json({ error: errorMessage("NOT_ENTITLED") }, { status: 403 });
+      }
+      if (!(await allowBindingCodeSend(request, userId))) {
+        return NextResponse.json({ error: "Too many verification requests. Please try again later." }, { status: 429 });
+      }
+    } catch {
+      return NextResponse.json({ error: "WhatsApp linking is temporarily unavailable. Please try again later." }, { status: 503 });
+    }
+  }
+  const result = begin.success
+    ? await beginWhatsAppBinding(userId, begin.data.phoneNumber)
+    : confirm.success
+      ? await confirmWhatsAppBinding(userId, confirm.data.code)
+      : null;
+  if (!result) return NextResponse.json({ error: "Invalid request" }, { status: 400 });
+  if (result.ok === false) return NextResponse.json({ error: errorMessage(result.code) }, { status: 400 });
+  return NextResponse.json(result);
+}
+
+export async function DELETE() {
+  const userId = await sessionUserId();
+  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  try {
+    await revokeWhatsAppBinding(userId);
+    return NextResponse.json({ success: true });
+  } catch {
+    return NextResponse.json({ error: "Unable to unlink WhatsApp" }, { status: 503 });
+  }
+}

--- a/src/app/api/webhooks/whatsapp/route.ts
+++ b/src/app/api/webhooks/whatsapp/route.ts
@@ -1,0 +1,112 @@
+import crypto from "crypto";
+import { NextRequest, NextResponse } from "next/server";
+import { Prisma } from "@prisma/client";
+import { z } from "zod";
+import { prisma } from "@/lib/db";
+import { encryptWhatsAppData } from "@/lib/whatsapp/crypto";
+import { processWhatsAppInboundEvent } from "@/lib/whatsapp/processor";
+import { hashWhatsAppIdentity, verifyWhatsAppWebhookSignature } from "@/lib/whatsapp/security";
+
+export const dynamic = "force-dynamic";
+
+const payloadSchema = z.object({
+  object: z.literal("whatsapp_business_account"),
+  entry: z.array(z.object({
+    changes: z.array(z.object({
+      value: z.object({
+        metadata: z.object({ phone_number_id: z.string() }),
+        contacts: z.array(z.object({ wa_id: z.string() })).optional(),
+        messages: z.array(z.object({
+          id: z.string(),
+          from: z.string(),
+          type: z.string(),
+          text: z.object({ body: z.string() }).optional(),
+        })).optional(),
+      }),
+    })),
+  })),
+});
+
+function sameSecret(value: string | null, expected: string | undefined): boolean {
+  if (!value || !expected || value.length !== expected.length) return false;
+  return crypto.timingSafeEqual(Buffer.from(value), Buffer.from(expected));
+}
+
+function senderIdentity(from: string): string | null {
+  return /^\d{8,15}$/.test(from) ? `+${from}` : null;
+}
+
+export async function GET(request: NextRequest) {
+  const query = request.nextUrl.searchParams;
+  if (
+    query.get("hub.mode") !== "subscribe" ||
+    !sameSecret(query.get("hub.verify_token"), process.env.WHATSAPP_VERIFY_TOKEN)
+  ) {
+    return new NextResponse("Forbidden", { status: 403 });
+  }
+  return new NextResponse(query.get("hub.challenge") || "", { status: 200 });
+}
+
+export async function POST(request: NextRequest) {
+  const rawBody = Buffer.from(await request.arrayBuffer());
+  try {
+    if (!verifyWhatsAppWebhookSignature(rawBody, request.headers.get("x-hub-signature-256"))) {
+      return new NextResponse("Unauthorized", { status: 401 });
+    }
+  } catch {
+    return new NextResponse("Unavailable", { status: 503 });
+  }
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(rawBody.toString("utf8"));
+  } catch {
+    return new NextResponse("Bad Request", { status: 400 });
+  }
+  const parsed = payloadSchema.safeParse(payload);
+  if (!parsed.success || !process.env.WHATSAPP_PHONE_NUMBER_ID) {
+    return new NextResponse("Bad Request", { status: 400 });
+  }
+
+  try {
+    for (const entry of parsed.data.entry) {
+      for (const change of entry.changes) {
+        const value = change.value;
+        if (value.metadata.phone_number_id !== process.env.WHATSAPP_PHONE_NUMBER_ID) continue;
+        for (const message of value.messages ?? []) {
+          const identity = senderIdentity(message.from);
+          if (!identity) continue;
+          const senderIdentityHash = hashWhatsAppIdentity(identity);
+          const binding = await prisma.whatsAppIdentityBinding.findUnique({
+            where: { identityHash: senderIdentityHash },
+            select: { id: true },
+          });
+          try {
+            const event = await prisma.whatsAppInboundEvent.create({
+              data: {
+                providerMessageId: message.id,
+                senderIdentityHash,
+                bindingId: binding?.id,
+                messageType: message.type,
+                encryptedText: message.type === "text" && message.text?.body
+                  ? encryptWhatsAppData(message.text.body)
+                  : null,
+                senderIdentityEncrypted: encryptWhatsAppData(identity),
+                purgeAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+              },
+            });
+            await processWhatsAppInboundEvent(event.id, message.from);
+          } catch (error) {
+            if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002") {
+              continue;
+            }
+            throw error;
+          }
+        }
+      }
+    }
+    return NextResponse.json({ received: true });
+  } catch {
+    return new NextResponse("Unavailable", { status: 503 });
+  }
+}

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -56,6 +56,36 @@ export const rateLimitConfigs = {
     window: "1 m" as const, // 10 requests per minute
     windowMs: 60 * 1000,
   },
+  whatsappHourly: {
+    requests: 20,
+    window: "1 h" as const,
+    windowMs: 60 * 60 * 1000,
+  },
+  whatsappDaily: {
+    requests: 60,
+    window: "1 d" as const,
+    windowMs: 24 * 60 * 60 * 1000,
+  },
+  whatsappGlobal: {
+    requests: 100,
+    window: "1 m" as const,
+    windowMs: 60 * 1000,
+  },
+  whatsappBindingUser: {
+    requests: 3,
+    window: "1 h" as const,
+    windowMs: 60 * 60 * 1000,
+  },
+  whatsappBindingIp: {
+    requests: 10,
+    window: "1 h" as const,
+    windowMs: 60 * 60 * 1000,
+  },
+  whatsappBindingGlobal: {
+    requests: 100,
+    window: "1 h" as const,
+    windowMs: 60 * 60 * 1000,
+  },
   // Contact: Contact form submissions (prevent email relay abuse)
   contact: {
     requests: 3,
@@ -70,7 +100,16 @@ type RateLimitConfig = keyof typeof rateLimitConfigs;
 // must deny (fail closed) for these rather than granting each cold instance a
 // fresh allowance.
 const FAIL_CLOSED_TIERS: ReadonlySet<RateLimitConfig> = new Set<RateLimitConfig>(
-  ["strict", "auth"],
+  [
+    "strict",
+    "auth",
+    "whatsappHourly",
+    "whatsappDaily",
+    "whatsappGlobal",
+    "whatsappBindingUser",
+    "whatsappBindingIp",
+    "whatsappBindingGlobal",
+  ],
 );
 
 /**

--- a/src/lib/whatsapp/binding.ts
+++ b/src/lib/whatsapp/binding.ts
@@ -1,0 +1,172 @@
+import crypto from "crypto";
+import { prisma } from "@/lib/db";
+import { decryptWhatsAppData, encryptWhatsAppData } from "./crypto";
+import { decideWhatsAppScanEntitlement } from "./entitlement";
+import { sendWhatsAppVerificationCode } from "./provider";
+import {
+  hashWhatsAppIdentity,
+  hashWhatsAppVerificationCode,
+  normalizeWhatsAppPhoneNumber,
+  verificationCodesMatch,
+} from "./security";
+
+const CODE_TTL_MS = 10 * 60 * 1000;
+const RESEND_COOLDOWN_MS = 60 * 1000;
+const MAX_VERIFICATION_ATTEMPTS = 5;
+
+export type BindingActionResult =
+  | { ok: true; maskedPhone?: string }
+  | { ok: false; code: "INVALID_PHONE" | "NUMBER_IN_USE" | "NOT_ENTITLED" | "TOO_SOON" | "INVALID_CODE" | "EXPIRED_CODE" | "UNAVAILABLE" };
+
+function makeVerificationCode(): string {
+  return crypto.randomInt(100000, 1_000_000).toString();
+}
+
+function maskPhoneNumber(phoneNumber: string): string {
+  return `${phoneNumber.slice(0, 3)}••••${phoneNumber.slice(-2)}`;
+}
+
+async function activePaidUser(userId: string): Promise<boolean> {
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { plan: true, deletedAt: true, subscriptionExpiresAt: true },
+  });
+  return decideWhatsAppScanEntitlement(user, { active: true, revokedAt: null }).allowed;
+}
+
+export async function isCurrentWhatsAppSubscriber(userId: string): Promise<boolean> {
+  try {
+    return await activePaidUser(userId);
+  } catch {
+    return false;
+  }
+}
+
+export async function beginWhatsAppBinding(
+  userId: string,
+  input: string,
+): Promise<BindingActionResult> {
+  const phoneNumber = normalizeWhatsAppPhoneNumber(input);
+  if (!phoneNumber) return { ok: false, code: "INVALID_PHONE" };
+
+  try {
+    if (!(await activePaidUser(userId))) return { ok: false, code: "NOT_ENTITLED" };
+
+    const identityHash = hashWhatsAppIdentity(phoneNumber);
+    const existing = await prisma.whatsAppIdentityBinding.findUnique({
+      where: { identityHash },
+      select: { userId: true, active: true, lastVerificationSentAt: true },
+    });
+    // Only a verified active binding reserves an identity. A stale or
+    // unverified attempt cannot squat on someone else's WhatsApp number.
+    if (existing?.active && existing.userId !== userId) return { ok: false, code: "NUMBER_IN_USE" };
+    if (
+      existing?.userId === userId && existing.lastVerificationSentAt &&
+      Date.now() - existing.lastVerificationSentAt.getTime() < RESEND_COOLDOWN_MS
+    ) {
+      return { ok: false, code: "TOO_SOON" };
+    }
+
+    const code = makeVerificationCode();
+    const now = new Date();
+    await prisma.whatsAppIdentityBinding.upsert({
+      where: { identityHash },
+      create: {
+        userId,
+        identityHash,
+        identityEncrypted: encryptWhatsAppData(phoneNumber),
+        verificationCodeHash: hashWhatsAppVerificationCode(code),
+        verificationExpiresAt: new Date(now.getTime() + CODE_TTL_MS),
+        lastVerificationSentAt: now,
+      },
+      update: {
+        userId,
+        identityEncrypted: encryptWhatsAppData(phoneNumber),
+        verificationCodeHash: hashWhatsAppVerificationCode(code),
+        verificationExpiresAt: new Date(now.getTime() + CODE_TTL_MS),
+        verificationAttempts: 0,
+        lastVerificationSentAt: now,
+        active: false,
+        revokedAt: null,
+      },
+    });
+    await sendWhatsAppVerificationCode(phoneNumber, code);
+    return { ok: true, maskedPhone: maskPhoneNumber(phoneNumber) };
+  } catch {
+    return { ok: false, code: "UNAVAILABLE" };
+  }
+}
+
+export async function confirmWhatsAppBinding(
+  userId: string,
+  code: string,
+): Promise<BindingActionResult> {
+  try {
+    if (!(await activePaidUser(userId))) return { ok: false, code: "NOT_ENTITLED" };
+    const binding = await prisma.whatsAppIdentityBinding.findFirst({
+      where: { userId, active: false, verificationCodeHash: { not: null } },
+      orderBy: { lastVerificationSentAt: "desc" },
+    });
+    if (!binding?.verificationCodeHash || !binding.verificationExpiresAt) {
+      return { ok: false, code: "INVALID_CODE" };
+    }
+    if (
+      binding.verificationExpiresAt <= new Date() ||
+      binding.verificationAttempts >= MAX_VERIFICATION_ATTEMPTS
+    ) {
+      return { ok: false, code: "EXPIRED_CODE" };
+    }
+    if (!/^\d{6}$/.test(code) || !verificationCodesMatch(code, binding.verificationCodeHash)) {
+      await prisma.whatsAppIdentityBinding.update({
+        where: { id: binding.id },
+        data: { verificationAttempts: { increment: 1 } },
+      });
+      return { ok: false, code: "INVALID_CODE" };
+    }
+
+    const maskedPhone = maskPhoneNumber(decryptWhatsAppData(binding.identityEncrypted));
+    await prisma.$transaction([
+      prisma.whatsAppIdentityBinding.updateMany({
+        where: { userId, active: true },
+        data: { active: false, revokedAt: new Date() },
+      }),
+      prisma.whatsAppIdentityBinding.update({
+        where: { id: binding.id },
+        data: {
+          active: true,
+          boundAt: new Date(),
+          revokedAt: null,
+          verificationCodeHash: null,
+          verificationExpiresAt: null,
+          verificationAttempts: 0,
+        },
+      }),
+    ]);
+    return { ok: true, maskedPhone };
+  } catch {
+    return { ok: false, code: "UNAVAILABLE" };
+  }
+}
+
+export async function revokeWhatsAppBinding(userId: string): Promise<void> {
+  await prisma.whatsAppIdentityBinding.updateMany({
+    where: { userId, active: true },
+    data: { active: false, revokedAt: new Date() },
+  });
+}
+
+export async function getWhatsAppBindingStatus(userId: string): Promise<{
+  active: boolean;
+  maskedPhone?: string;
+}> {
+  const binding = await prisma.whatsAppIdentityBinding.findFirst({
+    where: { userId, active: true, revokedAt: null },
+    orderBy: { boundAt: "desc" },
+  });
+  if (!binding) return { active: false };
+  try {
+    return { active: true, maskedPhone: maskPhoneNumber(decryptWhatsAppData(binding.identityEncrypted)) };
+  } catch {
+    return { active: true };
+  }
+}

--- a/src/lib/whatsapp/crypto.ts
+++ b/src/lib/whatsapp/crypto.ts
@@ -1,0 +1,34 @@
+import crypto from "crypto";
+
+const ALGORITHM = "aes-256-gcm";
+const IV_LENGTH = 12;
+const TAG_LENGTH = 16;
+
+function getWhatsAppEncryptionKey(): Buffer {
+  const secret = process.env.WHATSAPP_ENCRYPTION_KEY;
+  if (!secret) {
+    throw new Error("WHATSAPP_ENCRYPTION_KEY is required");
+  }
+  return crypto
+    .createHmac("sha256", "scamdunk-whatsapp-encryption-v1")
+    .update(secret)
+    .digest();
+}
+
+export function encryptWhatsAppData(plaintext: string): string {
+  const iv = crypto.randomBytes(IV_LENGTH);
+  const cipher = crypto.createCipheriv(ALGORITHM, getWhatsAppEncryptionKey(), iv);
+  const encrypted = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+  return Buffer.concat([iv, cipher.getAuthTag(), encrypted]).toString("base64");
+}
+
+export function decryptWhatsAppData(packed: string): string {
+  const bytes = Buffer.from(packed, "base64");
+  if (bytes.length <= IV_LENGTH + TAG_LENGTH) throw new Error("Invalid encrypted WhatsApp data");
+  const decipher = crypto.createDecipheriv(ALGORITHM, getWhatsAppEncryptionKey(), bytes.subarray(0, IV_LENGTH));
+  decipher.setAuthTag(bytes.subarray(IV_LENGTH, IV_LENGTH + TAG_LENGTH));
+  return Buffer.concat([
+    decipher.update(bytes.subarray(IV_LENGTH + TAG_LENGTH)),
+    decipher.final(),
+  ]).toString("utf8");
+}

--- a/src/lib/whatsapp/entitlement.ts
+++ b/src/lib/whatsapp/entitlement.ts
@@ -1,0 +1,71 @@
+import { prisma } from "@/lib/db";
+
+export type WhatsAppEntitlementDecision =
+  | { allowed: true }
+  | { allowed: false; reason: "NO_ACTIVE_ENTITLEMENT" };
+
+type EntitlementUser = {
+  plan: string;
+  deletedAt: Date | null;
+  subscriptionExpiresAt: Date | null;
+};
+
+type EntitlementBinding = {
+  active: boolean;
+  revokedAt: Date | null;
+};
+
+/** Pure fail-closed entitlement policy, kept separately for exhaustive tests. */
+export function decideWhatsAppScanEntitlement(
+  user: EntitlementUser | null,
+  binding: EntitlementBinding | null,
+  now: Date = new Date(),
+): WhatsAppEntitlementDecision {
+  if (
+    !user ||
+    !binding ||
+    user.deletedAt ||
+    user.plan !== "PAID" ||
+    !user.subscriptionExpiresAt ||
+    user.subscriptionExpiresAt <= now ||
+    !binding.active ||
+    binding.revokedAt
+  ) {
+    return { allowed: false, reason: "NO_ACTIVE_ENTITLEMENT" };
+  }
+
+  return { allowed: true };
+}
+
+/** Fresh database check. No session, cache, or client-supplied plan is trusted. */
+export async function resolveWhatsAppScanEntitlement(
+  userId: string,
+  identityHash: string,
+  now: Date = new Date(),
+): Promise<WhatsAppEntitlementDecision> {
+  try {
+    const binding = await prisma.whatsAppIdentityBinding.findUnique({
+      where: { identityHash },
+      select: {
+        userId: true,
+        active: true,
+        revokedAt: true,
+        user: {
+          select: {
+            plan: true,
+            deletedAt: true,
+            subscriptionExpiresAt: true,
+          },
+        },
+      },
+    });
+
+    if (!binding || binding.userId !== userId) {
+      return { allowed: false, reason: "NO_ACTIVE_ENTITLEMENT" };
+    }
+
+    return decideWhatsAppScanEntitlement(binding.user, binding, now);
+  } catch {
+    return { allowed: false, reason: "NO_ACTIVE_ENTITLEMENT" };
+  }
+}

--- a/src/lib/whatsapp/parser.ts
+++ b/src/lib/whatsapp/parser.ts
@@ -1,0 +1,29 @@
+export const WHATSAPP_INVALID_INPUT_REPLY =
+  "Send one stock ticker only, for example AAPL or scan AAPL.";
+
+export type WhatsAppStockScanParseResult =
+  | { ok: true; ticker: string }
+  | { ok: false; reply: typeof WHATSAPP_INVALID_INPUT_REPLY };
+
+const STOCK_SCAN_PATTERN = /^(?:scan )?([A-Za-z][A-Za-z0-9.-]{0,9})$/i;
+
+/**
+ * Parses the only two inbound WhatsApp forms supported by the MVP. This is
+ * deliberately isolated from the web scanner's broader free-text contract.
+ */
+export function parseWhatsAppStockScan(
+  input: string,
+): WhatsAppStockScanParseResult {
+  const normalized = input.normalize("NFKC").replace(/\s+/g, " ").trim();
+
+  if (!normalized || Array.from(normalized).length > 16) {
+    return { ok: false, reply: WHATSAPP_INVALID_INPUT_REPLY };
+  }
+
+  const match = normalized.match(STOCK_SCAN_PATTERN);
+  if (!match || /^scan(?:$|[A-Za-z])/i.test(normalized)) {
+    return { ok: false, reply: WHATSAPP_INVALID_INPUT_REPLY };
+  }
+
+  return { ok: true, ticker: match[1].toUpperCase() };
+}

--- a/src/lib/whatsapp/processor.ts
+++ b/src/lib/whatsapp/processor.ts
@@ -1,0 +1,181 @@
+import { NextRequest } from "next/server";
+import { prisma } from "@/lib/db";
+import { rateLimit } from "@/lib/rate-limit";
+import { decryptWhatsAppData, encryptWhatsAppData } from "./crypto";
+import { resolveWhatsAppScanEntitlement } from "./entitlement";
+import { WHATSAPP_INVALID_INPUT_REPLY, parseWhatsAppStockScan } from "./parser";
+import { sendWhatsAppTextReply } from "./provider";
+import { runAuthorizedStockScan } from "./scan";
+
+const UNBOUND_REPLY =
+  "This WhatsApp number is not eligible for ScamDunk scans. Manage WhatsApp access from your ScamDunk account.";
+const ENTITLEMENT_REPLY =
+  "WhatsApp scans require an active ScamDunk subscription. Manage your subscription in your ScamDunk account.";
+const QUOTA_REPLY =
+  "Your ScamDunk scan limit has been reached for this month. Manage your plan in your ScamDunk account.";
+const RATE_LIMIT_REPLY = "Too many scan requests. Please try again later.";
+const UNAVAILABLE_REPLY = "ScamDunk is temporarily unavailable. Please try again later.";
+const FAILED_SCAN_REPLY = "ScamDunk could not complete that scan. Please try again later.";
+
+function rateLimitRequest(identifier: string): NextRequest {
+  return new NextRequest("http://internal/whatsapp-rate-limit", {
+    headers: { "x-real-ip": identifier },
+  });
+}
+
+async function isAllowed(identityHash: string, userId: string): Promise<boolean> {
+  try {
+    const [hourly, daily, global] = await Promise.all([
+      rateLimit(rateLimitRequest(`whatsapp-identity:${identityHash}`), "whatsappHourly"),
+      rateLimit(rateLimitRequest(`whatsapp-user:${userId}`), "whatsappDaily"),
+      rateLimit(rateLimitRequest("whatsapp-global"), "whatsappGlobal"),
+    ]);
+    return hourly.success && daily.success && global.success;
+  } catch {
+    return false;
+  }
+}
+
+function conciseResult(ticker: string, riskLevel: string, header: string): string {
+  const summary = header.replace(/\s+/g, " ").trim().slice(0, 360);
+  return `ScamDunk scan: ${ticker} — ${riskLevel}. ${summary} This is risk-signal analysis, not investment advice.`;
+}
+
+async function respond(
+  eventId: string,
+  recipientWaId: string,
+  body: string,
+  status: string,
+  reasonCode: string,
+): Promise<void> {
+  let replyPersisted = false;
+  try {
+    // Persist the exact response before network delivery. A retry can then
+    // resend the reply without ever running another scan or consuming quota.
+    await prisma.whatsAppInboundEvent.update({
+      where: { id: eventId },
+      data: { status: "SENDING", reasonCode, encryptedReply: encryptWhatsAppData(body) },
+    });
+    replyPersisted = true;
+    const providerReplyMessageId = await sendWhatsAppTextReply(recipientWaId, body);
+    await prisma.whatsAppInboundEvent.update({
+      where: { id: eventId },
+      data: {
+        status,
+        reasonCode,
+        encryptedReply: encryptWhatsAppData(body),
+        providerReplyMessageId,
+        processedAt: new Date(),
+      },
+    });
+  } catch {
+    await prisma.whatsAppInboundEvent.update({
+      where: { id: eventId },
+      data: replyPersisted
+        ? { status: "RETRY", reasonCode: "PROVIDER_UNAVAILABLE", attemptCount: { increment: 1 } }
+        : { status: "FAILED", reasonCode: "REPLY_PERSIST_FAILED" },
+    });
+  }
+}
+
+/** Process one previously deduplicated provider event. Raw input never enters scan history. */
+export async function processWhatsAppInboundEvent(
+  eventId: string,
+  recipientWaId?: string,
+): Promise<void> {
+  const event = await prisma.whatsAppInboundEvent.findUnique({
+    where: { id: eventId },
+    include: { binding: true },
+  });
+  if (!event || !["RECEIVED", "RETRY", "SENDING"].includes(event.status)) return;
+
+  let recipient = recipientWaId;
+  if (!recipient && event.senderIdentityEncrypted) {
+    try {
+      recipient = decryptWhatsAppData(event.senderIdentityEncrypted).slice(1);
+    } catch {
+      await prisma.whatsAppInboundEvent.update({
+        where: { id: eventId },
+        data: { status: "FAILED", reasonCode: "IDENTITY_DECRYPT_FAILED" },
+      });
+      return;
+    }
+  }
+  if (!recipient) return;
+
+  if (event.status === "RETRY" || event.status === "SENDING") {
+    if (!event.encryptedReply) return;
+    try {
+      await respond(eventId, recipient, decryptWhatsAppData(event.encryptedReply), "REPLIED", event.reasonCode || "RETRY");
+    } catch {
+      // respond records the retry state and attempt count.
+    }
+    return;
+  }
+
+  const claimed = await prisma.whatsAppInboundEvent.updateMany({
+    where: { id: eventId, status: "RECEIVED" },
+    data: { status: "PROCESSING", attemptCount: { increment: 1 } },
+  });
+  if (claimed.count !== 1) return;
+
+  if (event.messageType !== "text" || !event.encryptedText) {
+    await respond(eventId, recipient, WHATSAPP_INVALID_INPUT_REPLY, "REPLIED", "INVALID_INPUT");
+    return;
+  }
+  if (!event.binding?.active || event.binding.revokedAt) {
+    await respond(eventId, recipient, UNBOUND_REPLY, "REPLIED", "UNBOUND");
+    return;
+  }
+  const entitlement = await resolveWhatsAppScanEntitlement(event.binding.userId, event.senderIdentityHash);
+  if (entitlement.allowed === false) {
+    await respond(eventId, recipient, ENTITLEMENT_REPLY, "REPLIED", entitlement.reason);
+    return;
+  }
+  if (!(await isAllowed(event.senderIdentityHash, event.binding.userId))) {
+    await respond(eventId, recipient, RATE_LIMIT_REPLY, "REPLIED", "RATE_LIMITED");
+    return;
+  }
+
+  let text: string;
+  try {
+    text = decryptWhatsAppData(event.encryptedText);
+  } catch {
+    await respond(eventId, recipient, UNAVAILABLE_REPLY, "FAILED", "DECRYPT_FAILED");
+    return;
+  }
+  const parsed = parseWhatsAppStockScan(text);
+  if (parsed.ok === false) {
+    await respond(eventId, recipient, parsed.reply, "REPLIED", "INVALID_INPUT");
+    return;
+  }
+
+  await prisma.whatsAppInboundEvent.update({
+    where: { id: eventId },
+    data: { status: "SCANNING" },
+  });
+
+  const scan = await runAuthorizedStockScan({
+    userId: event.binding.userId,
+    ticker: parsed.ticker,
+    assetType: "stock",
+  });
+  if (!scan.ok) {
+    const body = scan.body as { error?: string };
+    if (scan.status === 429 && body.error === "LIMIT_REACHED") {
+      await respond(eventId, recipient, QUOTA_REPLY, "REPLIED", "QUOTA_EXHAUSTED");
+    } else if (scan.status >= 500) {
+      await respond(eventId, recipient, FAILED_SCAN_REPLY, "FAILED", "SCAN_FAILED");
+    } else {
+      await respond(eventId, recipient, UNAVAILABLE_REPLY, "FAILED", "SCAN_UNAVAILABLE");
+    }
+    return;
+  }
+  await respond(
+    eventId,
+    recipient,
+    conciseResult(parsed.ticker, scan.body.riskLevel, scan.body.narrative.header),
+    "REPLIED",
+    "SCAN_COMPLETED",
+  );
+}

--- a/src/lib/whatsapp/provider.ts
+++ b/src/lib/whatsapp/provider.ts
@@ -1,0 +1,62 @@
+type WhatsAppProviderResponse = { messages?: Array<{ id?: string }> };
+
+function providerConfig() {
+  const accessToken = process.env.WHATSAPP_ACCESS_TOKEN;
+  const phoneNumberId = process.env.WHATSAPP_PHONE_NUMBER_ID;
+  const templateName = process.env.WHATSAPP_VERIFICATION_TEMPLATE;
+  if (!accessToken || !phoneNumberId || !templateName) {
+    throw new Error("WHATSAPP_PROVIDER_NOT_CONFIGURED");
+  }
+  return { accessToken, phoneNumberId, templateName };
+}
+
+async function postMessage(body: object): Promise<string | null> {
+  const { accessToken, phoneNumberId } = providerConfig();
+  const response = await fetch(
+    `https://graph.facebook.com/v20.0/${phoneNumberId}/messages`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ messaging_product: "whatsapp", ...body }),
+    },
+  );
+  if (!response.ok) throw new Error("WHATSAPP_PROVIDER_SEND_FAILED");
+  const data = (await response.json()) as WhatsAppProviderResponse;
+  return data.messages?.[0]?.id ?? null;
+}
+
+/** The configured Meta authentication template must have one body variable: code. */
+export async function sendWhatsAppVerificationCode(
+  phoneNumber: string,
+  code: string,
+): Promise<string | null> {
+  const { templateName } = providerConfig();
+  return postMessage({
+    to: phoneNumber.slice(1),
+    type: "template",
+    template: {
+      name: templateName,
+      language: { code: "en_US" },
+      components: [
+        {
+          type: "body",
+          parameters: [{ type: "text", text: code }],
+        },
+      ],
+    },
+  });
+}
+
+export async function sendWhatsAppTextReply(
+  recipientWaId: string,
+  body: string,
+): Promise<string | null> {
+  return postMessage({
+    to: recipientWaId,
+    type: "text",
+    text: { preview_url: false, body },
+  });
+}

--- a/src/lib/whatsapp/scan.ts
+++ b/src/lib/whatsapp/scan.ts
@@ -1,0 +1,3 @@
+import { runAuthorizedStockScan } from "@/app/api/check/route";
+
+export { runAuthorizedStockScan };

--- a/src/lib/whatsapp/security.ts
+++ b/src/lib/whatsapp/security.ts
@@ -1,0 +1,52 @@
+import crypto from "crypto";
+
+function requireSecret(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`${name} is required`);
+  }
+  return value;
+}
+
+/** Normalize a user-provided number to the E.164 identity Meta sends. */
+export function normalizeWhatsAppPhoneNumber(input: string): string | null {
+  const compact = input.trim().replace(/[\s().-]/g, "");
+  if (!/^\+[1-9]\d{7,14}$/.test(compact)) {
+    return null;
+  }
+  return compact;
+}
+
+/** A deterministic, non-reversible lookup index. Never log its input. */
+export function hashWhatsAppIdentity(identity: string): string {
+  return crypto
+    .createHmac("sha256", requireSecret("WHATSAPP_IDENTITY_HASH_KEY"))
+    .update(identity)
+    .digest("hex");
+}
+
+/** Verify Meta's sha256=<hex> HMAC against the exact raw request body. */
+export function verifyWhatsAppWebhookSignature(
+  rawBody: Buffer,
+  header: string | null,
+): boolean {
+  if (!header?.startsWith("sha256=")) return false;
+
+  const expected = crypto
+    .createHmac("sha256", requireSecret("WHATSAPP_APP_SECRET"))
+    .update(rawBody)
+    .digest("hex");
+  const provided = header.slice("sha256=".length);
+
+  if (provided.length !== expected.length) return false;
+  return crypto.timingSafeEqual(Buffer.from(provided), Buffer.from(expected));
+}
+
+export function hashWhatsAppVerificationCode(code: string): string {
+  return crypto.createHash("sha256").update(code).digest("hex");
+}
+
+export function verificationCodesMatch(code: string, expectedHash: string): boolean {
+  const actualHash = hashWhatsAppVerificationCode(code);
+  return crypto.timingSafeEqual(Buffer.from(actualHash), Buffer.from(expectedHash));
+}

--- a/src/tests/e2e.test.ts
+++ b/src/tests/e2e.test.ts
@@ -374,6 +374,23 @@ describe("End-to-End Integration Tests", () => {
   });
 
   describe("Narrative Generation (Fallback)", () => {
+    const originalOpenAIKey = process.env.OPENAI_API_KEY;
+
+    beforeAll(() => {
+      // These cases assert the deterministic fallback contract. A developer
+      // shell with an OpenAI key must not turn them into live, nondeterministic
+      // network tests.
+      delete process.env.OPENAI_API_KEY;
+    });
+
+    afterAll(() => {
+      if (originalOpenAIKey === undefined) {
+        delete process.env.OPENAI_API_KEY;
+      } else {
+        process.env.OPENAI_API_KEY = originalOpenAIKey;
+      }
+    });
+
     it("should generate HIGH risk narrative", async () => {
       const signals = [
         {

--- a/src/tests/whatsapp-entitlement.test.ts
+++ b/src/tests/whatsapp-entitlement.test.ts
@@ -1,0 +1,32 @@
+import { decideWhatsAppScanEntitlement } from "@/lib/whatsapp/entitlement";
+
+const now = new Date("2026-08-09T12:00:00.000Z");
+
+describe("decideWhatsAppScanEntitlement", () => {
+  it("allows only an active binding for a paid, non-deleted user with future expiry", () => {
+    expect(
+      decideWhatsAppScanEntitlement(
+        {
+          plan: "PAID",
+          deletedAt: null,
+          subscriptionExpiresAt: new Date("2026-08-10T00:00:00.000Z"),
+        },
+        { active: true, revokedAt: null },
+        now,
+      ),
+    ).toEqual({ allowed: true });
+  });
+
+  it.each([
+    [{ plan: "FREE", deletedAt: null, subscriptionExpiresAt: new Date("2026-08-10") }, { active: true, revokedAt: null }],
+    [{ plan: "PAID", deletedAt: new Date("2026-08-01"), subscriptionExpiresAt: new Date("2026-08-10") }, { active: true, revokedAt: null }],
+    [{ plan: "PAID", deletedAt: null, subscriptionExpiresAt: null }, { active: true, revokedAt: null }],
+    [{ plan: "PAID", deletedAt: null, subscriptionExpiresAt: new Date("2026-08-09T12:00:00.000Z") }, { active: true, revokedAt: null }],
+    [{ plan: "PAID", deletedAt: null, subscriptionExpiresAt: new Date("2026-08-10") }, { active: false, revokedAt: new Date("2026-08-01") }],
+  ])("denies every ambiguous or inactive state", (user, binding) => {
+    expect(decideWhatsAppScanEntitlement(user, binding, now)).toEqual({
+      allowed: false,
+      reason: "NO_ACTIVE_ENTITLEMENT",
+    });
+  });
+});

--- a/src/tests/whatsapp-parser.test.ts
+++ b/src/tests/whatsapp-parser.test.ts
@@ -1,0 +1,34 @@
+import {
+  parseWhatsAppStockScan,
+  WHATSAPP_INVALID_INPUT_REPLY,
+} from "@/lib/whatsapp/parser";
+
+describe("parseWhatsAppStockScan", () => {
+  it.each([
+    ["AAPL", "AAPL"],
+    ["aapl", "AAPL"],
+    ["  scan   aapl  ", "AAPL"],
+    ["BRK.B", "BRK.B"],
+    ["BF-B", "BF-B"],
+    ["ＡＡＰＬ", "AAPL"],
+  ])("accepts the supported scan grammar: %s", (input, ticker) => {
+    expect(parseWhatsAppStockScan(input)).toEqual({ ok: true, ticker });
+  });
+
+  it.each([
+    "",
+    "scan",
+    "scanAAPL",
+    "AAPL MSFT",
+    "AAPL,",
+    "$AAPL",
+    "scan AAPL now",
+    "AAPL\nMSFT",
+    "ABCDEFGHIJK",
+  ])("rejects input outside the two-form scan grammar: %p", (input) => {
+    expect(parseWhatsAppStockScan(input)).toEqual({
+      ok: false,
+      reply: WHATSAPP_INVALID_INPUT_REPLY,
+    });
+  });
+});

--- a/src/tests/whatsapp-security.test.ts
+++ b/src/tests/whatsapp-security.test.ts
@@ -1,0 +1,43 @@
+import crypto from "crypto";
+import {
+  hashWhatsAppIdentity,
+  normalizeWhatsAppPhoneNumber,
+  verifyWhatsAppWebhookSignature,
+} from "@/lib/whatsapp/security";
+
+describe("WhatsApp security primitives", () => {
+  const originalAppSecret = process.env.WHATSAPP_APP_SECRET;
+  const originalHashKey = process.env.WHATSAPP_IDENTITY_HASH_KEY;
+
+  beforeEach(() => {
+    process.env.WHATSAPP_APP_SECRET = "webhook-secret";
+    process.env.WHATSAPP_IDENTITY_HASH_KEY = "identity-secret";
+  });
+
+  afterAll(() => {
+    process.env.WHATSAPP_APP_SECRET = originalAppSecret;
+    process.env.WHATSAPP_IDENTITY_HASH_KEY = originalHashKey;
+  });
+
+  it("validates an HMAC over the exact raw webhook bytes", () => {
+    const rawBody = Buffer.from('{"object":"whatsapp_business_account"}');
+    const signature = `sha256=${crypto
+      .createHmac("sha256", "webhook-secret")
+      .update(rawBody)
+      .digest("hex")}`;
+
+    expect(verifyWhatsAppWebhookSignature(rawBody, signature)).toBe(true);
+    expect(verifyWhatsAppWebhookSignature(rawBody, "sha256=bad")).toBe(false);
+    expect(
+      verifyWhatsAppWebhookSignature(Buffer.from("different"), signature),
+    ).toBe(false);
+  });
+
+  it("normalizes E.164 identities and makes their index non-reversible", () => {
+    expect(normalizeWhatsAppPhoneNumber("+1 (212) 555-0199")).toBe(
+      "+12125550199",
+    );
+    expect(normalizeWhatsAppPhoneNumber("12125550199")).toBeNull();
+    expect(hashWhatsAppIdentity("+12125550199")).not.toContain("12125550199");
+  });
+});

--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,10 @@
     {
       "path": "/api/cron/ingest-evaluation",
       "schedule": "0 7 * * 1-5"
+    },
+    {
+      "path": "/api/cron/whatsapp-retention",
+      "schedule": "17 * * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add a secure web-to-WhatsApp identity binding flow for active paid subscribers
- add signed, idempotent WhatsApp scan ingress with strict ticker-only parsing and shared scan execution
- add encrypted event retention, retry/dead-letter handling, entitlement checks, and fail-closed rate limits
- add Prisma migration, account UI, and focused parser/security/entitlement tests

## Verification
- npm test -- --runInBand --silent (96 passing)
- npm run typecheck
- npm run lint (existing repository warnings only)
- npm run build

## Notes
- Provider sandbox configuration remains external: Meta business assets, approved verification template, and the required server-side WhatsApp secrets.