### PR TITLE
Live daily scan stats on landing page and logged-in home

### DIFF
--- a/src/app/HomeContent.tsx
+++ b/src/app/HomeContent.tsx
@@ -601,7 +601,7 @@ export default function HomeContent() {
                           statTiles.dumpsConfirmed6mo,
                           "pump-and-dumps confirmed (6 mo)",
                         ],
-                        [statTiles.newFlagsThisWeek, "new flags this week"],
+                        [statTiles.pumpingNow, "suspected pumps live now"],
                       ].map(([num, label]) => (
                         <div key={label}>
                           <p className="font-editorial text-2xl text-foreground">

--- a/src/app/HomeContent.tsx
+++ b/src/app/HomeContent.tsx
@@ -21,6 +21,7 @@ import {
 } from "@/lib/types";
 import { getRandomTagline, taglines, Tagline } from "@/lib/taglines";
 import { LandingOptionA } from "@/components/landing/LandingOptionA";
+import { useLiveSiteStats } from "@/lib/use-site-stats";
 import { useToast } from "@/components/ui/toast";
 import { normalizeRiskScore } from "@/lib/utils";
 import { Step } from "@/components/LoadingStepper";
@@ -28,6 +29,7 @@ import { Step } from "@/components/LoadingStepper";
 export default function HomeContent() {
   const { data: session, status } = useSession();
   const { addToast } = useToast();
+  const { tiles: statTiles } = useLiveSiteStats();
 
   // Sidebar defaults closed for non-logged-in users (landing page)
   const [sidebarOpen, setSidebarOpen] = useState(false);
@@ -576,7 +578,7 @@ export default function HomeContent() {
                   )}
 
                   <div
-                    className="w-full max-w-3xl mx-auto mt-2 mb-12 animate-fade-in"
+                    className="w-full max-w-3xl mx-auto mt-2 mb-10 animate-fade-in"
                     style={{ animationDelay: "0.05s" }}
                   >
                     <ScanInput
@@ -584,6 +586,33 @@ export default function HomeContent() {
                       isLoading={isLoading}
                       disabled={usage?.limitReached && !result}
                     />
+                  </div>
+
+                  {/* Live scan stats — refreshed after each daily scan */}
+                  <div
+                    className="w-full max-w-3xl mx-auto mb-12 animate-fade-in"
+                    style={{ animationDelay: "0.1s" }}
+                  >
+                    <div className="grid grid-cols-2 gap-4 rounded-2xl border border-border bg-card px-6 py-5 text-center sm:grid-cols-4">
+                      {[
+                        [statTiles.stocksPerDay, "stocks scanned daily"],
+                        [statTiles.totalScans, "scans since January"],
+                        [
+                          statTiles.dumpsConfirmed6mo,
+                          "pump-and-dumps confirmed (6 mo)",
+                        ],
+                        [statTiles.newFlagsThisWeek, "new flags this week"],
+                      ].map(([num, label]) => (
+                        <div key={label}>
+                          <p className="font-editorial text-2xl text-foreground">
+                            {num}
+                          </p>
+                          <p className="mt-1 text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">
+                            {label}
+                          </p>
+                        </div>
+                      ))}
+                    </div>
                   </div>
                 </div>
               ) : (

--- a/src/app/api/stats/site/route.ts
+++ b/src/app/api/stats/site/route.ts
@@ -1,0 +1,68 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/db";
+
+// Public marketing stats, recomputed after each daily scan lands. Cached for
+// 6 hours: the underlying numbers only move once per trading day.
+export const revalidate = 21600;
+
+interface SiteStatsRow {
+  dump_symbols_6mo: bigint;
+  dump_symbols_30d: bigint;
+  flag_symbols_7d: bigint;
+  flag_symbols_30d: bigint;
+  pumping_now: bigint;
+}
+
+export async function GET() {
+  try {
+    const [latestScan, totals, rows] = await Promise.all([
+      prisma.dailyScanSummary.findFirst({
+        orderBy: { scanDate: "desc" },
+        select: { scanDate: true, evaluated: true, highRiskCount: true },
+      }),
+      prisma.dailyScanSummary.aggregate({ _sum: { evaluated: true } }),
+      prisma.$queryRaw<SiteStatsRow[]>`
+        SELECT
+          (SELECT COUNT(DISTINCT symbol) FROM "PromotedStock"
+            WHERE outcome IN ('DUMPED','DELISTED')
+              AND "addedDate" > now() - interval '6 months') AS dump_symbols_6mo,
+          (SELECT COUNT(DISTINCT symbol) FROM "PromotedStock"
+            WHERE outcome IN ('DUMPED','DELISTED')
+              AND "addedDate" > now() - interval '30 days') AS dump_symbols_30d,
+          (SELECT COUNT(DISTINCT symbol) FROM "PromotedStock"
+            WHERE "addedDate" > now() - interval '7 days') AS flag_symbols_7d,
+          (SELECT COUNT(DISTINCT symbol) FROM "PromotedStock"
+            WHERE "addedDate" > now() - interval '30 days') AS flag_symbols_30d,
+          (SELECT COUNT(DISTINCT symbol) FROM "PromotedStock"
+            WHERE outcome = 'PUMPING' AND "isActive") AS pumping_now
+      `,
+    ]);
+
+    const row = rows[0];
+    const stats = {
+      updatedAt: new Date().toISOString(),
+      lastScanDate: latestScan?.scanDate?.toISOString() ?? null,
+      stocksPerDay: latestScan?.evaluated ?? null,
+      highRiskLastScan: latestScan?.highRiskCount ?? null,
+      totalScans: totals._sum.evaluated ?? null,
+      dumpsConfirmed6mo: Number(row?.dump_symbols_6mo ?? 0),
+      dumpsConfirmed30d: Number(row?.dump_symbols_30d ?? 0),
+      newFlagSymbols7d: Number(row?.flag_symbols_7d ?? 0),
+      newFlagSymbols30d: Number(row?.flag_symbols_30d ?? 0),
+      pumpingNow: Number(row?.pumping_now ?? 0),
+    };
+
+    return NextResponse.json(stats, {
+      headers: {
+        "Cache-Control":
+          "public, s-maxage=21600, stale-while-revalidate=86400",
+      },
+    });
+  } catch (error) {
+    console.error("Failed to compute site stats:", error);
+    return NextResponse.json(
+      { error: "Stats unavailable" },
+      { status: 503 },
+    );
+  }
+}

--- a/src/components/landing/LandingOptionA.tsx
+++ b/src/components/landing/LandingOptionA.tsx
@@ -13,6 +13,7 @@ import {
 import { Footer } from "@/components/Footer";
 import { AssetType } from "@/lib/types";
 import { SITE_STATS } from "@/lib/site-stats";
+import { useLiveSiteStats } from "@/lib/use-site-stats";
 
 interface LandingOptionAProps {
   onSubmit: (data: {
@@ -59,6 +60,7 @@ export function LandingOptionA({
 }: LandingOptionAProps) {
   const [value, setValue] = useState("");
   const [inputError, setInputError] = useState<string | null>(null);
+  const { tiles } = useLiveSiteStats();
 
   const handleCheck = () => {
     const parsed = extractTicker(value);
@@ -188,13 +190,14 @@ export function LandingOptionA({
         </div>
       </section>
 
-      {/* ================= STATS STRIP ================= */}
+      {/* ================= STATS STRIP (live, refreshed daily) ================= */}
       <section className="bg-background py-12 md:py-16">
-        <div className="mx-auto grid max-w-4xl grid-cols-1 gap-10 px-4 text-center sm:grid-cols-3">
+        <div className="mx-auto grid max-w-5xl grid-cols-2 gap-x-6 gap-y-10 px-4 text-center lg:grid-cols-4">
           {[
-            [SITE_STATS.scansPerformed, SITE_STATS.scansPerformedLabel],
-            [SITE_STATS.fraudLosses, SITE_STATS.fraudLossesLabel],
-            [SITE_STATS.scanTime, SITE_STATS.scanTimeLabel],
+            [tiles.stocksPerDay, "stocks scanned every trading day"],
+            [tiles.totalScans, "stock scans since January"],
+            [tiles.dumpsConfirmed6mo, "pump-and-dumps confirmed in 6 months"],
+            [tiles.newFlagsThisWeek, "new stocks flagged this week"],
           ].map(([num, label]) => (
             <div key={label}>
               <p className="font-editorial text-4xl text-foreground md:text-[2.75rem]">
@@ -206,6 +209,10 @@ export function LandingOptionA({
             </div>
           ))}
         </div>
+        <p className="mt-8 text-center text-xs text-muted-foreground">
+          Live from our scan database · updated after every daily scan ·{" "}
+          {SITE_STATS.fraudLosses} {SITE_STATS.fraudLossesLabel}
+        </p>
       </section>
 
       {/* ================= POSITIONING ================= */}

--- a/src/components/landing/LandingOptionA.tsx
+++ b/src/components/landing/LandingOptionA.tsx
@@ -197,7 +197,7 @@ export function LandingOptionA({
             [tiles.stocksPerDay, "stocks scanned every trading day"],
             [tiles.totalScans, "stock scans since January"],
             [tiles.dumpsConfirmed6mo, "pump-and-dumps confirmed in 6 months"],
-            [tiles.newFlagsThisWeek, "new stocks flagged this week"],
+            [tiles.pumpingNow, "suspected pumps live right now"],
           ].map(([num, label]) => (
             <div key={label}>
               <p className="font-editorial text-4xl text-foreground md:text-[2.75rem]">

--- a/src/lib/use-site-stats.ts
+++ b/src/lib/use-site-stats.ts
@@ -54,7 +54,7 @@ export function useLiveSiteStats() {
         ? floorPlus(live.totalScans, 1000)
         : SITE_STATS.scansPerformed,
       dumpsConfirmed6mo: live ? String(live.dumpsConfirmed6mo) : "400+",
-      newFlagsThisWeek: live ? String(live.newFlagSymbols7d) : "30+",
+      pumpingNow: live ? String(live.pumpingNow) : "60+",
     },
   };
 }

--- a/src/lib/use-site-stats.ts
+++ b/src/lib/use-site-stats.ts
@@ -1,0 +1,60 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { SITE_STATS } from "@/lib/site-stats";
+
+export interface LiveSiteStats {
+  updatedAt: string;
+  lastScanDate: string | null;
+  stocksPerDay: number | null;
+  highRiskLastScan: number | null;
+  totalScans: number | null;
+  dumpsConfirmed6mo: number;
+  dumpsConfirmed30d: number;
+  newFlagSymbols7d: number;
+  newFlagSymbols30d: number;
+  pumpingNow: number;
+}
+
+/** Round DOWN to a stable marketing floor: 6,567 → "6,500+", 826,848 → "826,000+". */
+export function floorPlus(n: number, step: number): string {
+  return `${(Math.floor(n / step) * step).toLocaleString("en-US")}+`;
+}
+
+/**
+ * Live scan statistics for public/marketing surfaces. Renders the static
+ * SITE_STATS floors immediately and swaps in fresh numbers from
+ * /api/stats/site (recomputed after each daily scan) once loaded — no layout
+ * shift, graceful degradation if the API is unreachable.
+ */
+export function useLiveSiteStats() {
+  const [live, setLive] = useState<LiveSiteStats | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/stats/site")
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (!cancelled && data && !data.error) setLive(data);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return {
+    live,
+    /** Four headline tiles, static floors until live data arrives. */
+    tiles: {
+      stocksPerDay: live?.stocksPerDay
+        ? floorPlus(live.stocksPerDay, 100)
+        : SITE_STATS.stocksPerDay,
+      totalScans: live?.totalScans
+        ? floorPlus(live.totalScans, 1000)
+        : SITE_STATS.scansPerformed,
+      dumpsConfirmed6mo: live ? String(live.dumpsConfirmed6mo) : "400+",
+      newFlagsThisWeek: live ? String(live.newFlagSymbols7d) : "30+",
+    },
+  };
+}


### PR DESCRIPTION
## What's in this PR

Replaces the hand-maintained static stats strip with live numbers from the scan database, recomputed after each daily scan (6-hour cache with stale-while-revalidate):

- **`/api/stats/site`**: latest scan size, cumulative evaluations, distinct symbols dumped/delisted (6mo/30d), new flag symbols (week/month), live pumping count.
- **`useLiveSiteStats()`**: renders static floors immediately, swaps in live numbers once fetched — no layout shift, graceful fallback if the API is unreachable.
- **Landing stats strip** becomes four live tiles: stocks scanned per trading day (6,500+), total scans since January (826,000+), pump-and-dumps confirmed in 6 months (416), and suspected pumps live right now (61). The FBI fraud-losses figure moves to the caption line.
- **Logged-in home** gets a compact 4-stat card under the scan input with the same numbers.

## Testing
- `npm run build` passes; `tsc --noEmit` clean.
- API query shapes verified against the production database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YEJG4EqmJm6k1v5Uiqy5pJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01YEJG4EqmJm6k1v5Uiqy5pJ)_